### PR TITLE
Implement code to unregister all listeners used by LWC and load again

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1991,6 +1991,7 @@ public class LWC {
      */
     public void reload() {
         plugin.loadLocales();
+        plugin.loadEvents();
         protectionConfigurationCache.clear();
         Configuration.reload();
         moduleLoader.dispatchEvent(new LWCReloadEvent());

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -492,6 +492,14 @@ public class LWCPlugin extends JavaPlugin {
     }
 
     /**
+     * Unregister all events used by LWC and load again.
+     */
+    protected void loadEvents() {
+        org.bukkit.event.HandlerList.unregisterAll(this);
+        registerEvents();
+    }
+
+    /**
      * @return the current locale in use
      */
     public String getCurrentLocale() {


### PR DESCRIPTION
This can be useful when an event has run multiple times, but on reload unregistering the listener and load it.

I also put it in a protected method to prevent them from accessing it, so it's only available in that project package.