### PR TITLE
Add option for more efficient, alternative hopper protection

### DIFF
--- a/src/config/core.yml
+++ b/src/config/core.yml
@@ -77,7 +77,13 @@ optional:
     # If true, LWC will show certain (not all) messages in the action bar instead of the chat.
     # Spigot or better is recommended. This option will have no effect on CraftBukkit servers.
     useActionBar: false
-
+    
+    # This disables protection checks for any item moves except for hopper minecarts. Protection against
+    # hoppers is now done by checking for protections of the containers that the hopper is pointing into
+    # or that are above the hopper when the player places a hopper. If the player doesn't have access to
+    # that protection or the hopper flag isn't allowing it then the placement is blocked.
+    alternativeHopperProtection: false
+    
 # Database information for LWC
 database:
 

--- a/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -460,6 +460,11 @@ public class LWCPlayerListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onMoveItem(InventoryMoveItemEvent event) {
+        if (plugin.getLWC().useAlternativeHopperProtection()
+                && !(event.getSource().getHolder() instanceof HopperMinecart || event.getDestination().getHolder() instanceof HopperMinecart)) {
+            return;
+        }
+
         boolean result;
 
         // if the initiator is the same as the source it is a dropper i.e.

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -206,10 +206,16 @@ public class LWC {
      */
     private final Map<String, String> protectionConfigurationCache = new HashMap<>();
 
+    /**
+     * Whether alternative-hopper-protection is enabled
+     */
+    private boolean alternativeHoppers;
+
     public LWC(LWCPlugin plugin) {
         this.plugin = plugin;
         LWC.instance = this;
         configuration = Configuration.load("core.yml");
+        alternativeHoppers = configuration.getBoolean("optional.alternativeHopperProtection", false);
         protectionCache = new ProtectionCache(this);
         backupManager = new BackupManager();
         moduleLoader = new ModuleLoader(this);
@@ -1996,6 +2002,7 @@ public class LWC {
         plugin.loadEvents();
         protectionConfigurationCache.clear();
         Configuration.reload();
+        alternativeHoppers = configuration.getBoolean("optional.alternativeHopperProtection", false);
         moduleLoader.dispatchEvent(new LWCReloadEvent());
     }
 
@@ -2141,6 +2148,13 @@ public class LWC {
      */
     public boolean isHistoryEnabled() {
         return !configuration.getBoolean("core.disableHistory", false);
+    }
+
+    /**
+     * @return true if alternative hopper protection is enabled
+     */
+    public boolean useAlternativeHopperProtection() {
+        return alternativeHoppers;
     }
 
     public boolean enforceAccess(Player player, Protection protection, Entity entity, boolean hasAccess) {


### PR DESCRIPTION
This disables protection checks for any item moves except for hopper minecarts. Protection against hoppers is now done by checking for protections of the containers that the hopper is pointing into or that are above the hopper when the player places a hopper. If the player doesn't have access to that protection or the hopper flag isn't allowing it then the placement is blocked.