### PR TITLE
Fix issues with protection configuration and wildcards

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1407,20 +1407,30 @@ public class LWC {
 
         String materialName = normalizeMaterialName(material);
 
-        // add the name & the block id
-        names.add(materialName);
+        // add the the names with the block data byte
         names.add(materialName + ":" + state.getRawData());
+        names.add(material.toString() + ":" + state.getRawData());
+        names.add(material.toString().toLowerCase() + ":" + state.getRawData());
 
-        // add both upper and lower material name
+        // add the names without the block data
+        names.add(materialName);
         names.add(material.toString());
         names.add(material.toString().toLowerCase());
 
-        // Add the wildcards last so it can be overriden
-        names.add("*");
-
         if (materialName.contains("_")) { // Prefix wildcarding for shulker boxes & gates
-            names.add("*_" + materialName.substring(materialName.indexOf("_") + 1));
+            int i = materialName.indexOf("_") + 1;
+            while (i > 0) {
+                names.add("*_" + materialName.substring(i) + ":" + state.getRawData());
+                names.add("*_" + materialName.substring(i).toLowerCase() + ":" + state.getRawData());
+                names.add("*_" + materialName.substring(i));
+                names.add("*_" + materialName.substring(i).toLowerCase());
+                i = materialName.indexOf("_", i) + 1;
+            }
         }
+
+        // Add the wildcards last so it can be overriden
+        names.add("*:" + state.getRawData());
+        names.add("*");
 
         String value = configuration.getString("protections." + node);
 
@@ -1429,6 +1439,7 @@ public class LWC {
 
             if (temp != null && !temp.isEmpty()) {
                 value = temp;
+                break;
             }
         }
 
@@ -1574,20 +1585,30 @@ public class LWC {
 
         String materialName = normalizeMaterialName(material);
 
-        // add the name & the block id
-        names.add(materialName);
+        // add the the names with the block data byte
         names.add(materialName + ":" + block.getData());
+        names.add(material.toString() + ":" + block.getData());
+        names.add(material.toString().toLowerCase() + ":" + block.getData());
 
-        // add both upper and lower material name
+        // add the names without the block data
+        names.add(materialName);
         names.add(material.toString());
         names.add(material.toString().toLowerCase());
 
-        // Add the wildcards last so it can be overriden
-        names.add("*");
-
         if (materialName.contains("_")) { // Prefix wildcarding for shulker boxes & gates
-            names.add("*_" + materialName.substring(materialName.indexOf("_") + 1));
+            int i = materialName.indexOf("_") + 1;
+            while (i > 0) {
+                names.add("*_" + materialName.substring(i) + ":" + block.getData());
+                names.add("*_" + materialName.substring(i).toLowerCase() + ":" + block.getData());
+                names.add("*_" + materialName.substring(i));
+                names.add("*_" + materialName.substring(i).toLowerCase());
+                i = materialName.indexOf("_", i) + 1;
+            }
         }
+
+        // Add the wildcards last so it can be overriden
+        names.add("*:" + block.getData());
+        names.add("*");
 
         String value = configuration.getString("protections." + node);
 
@@ -1596,6 +1617,7 @@ public class LWC {
 
             if (temp != null && !temp.isEmpty()) {
                 value = temp;
+                break;
             }
         }
 
@@ -1630,6 +1652,15 @@ public class LWC {
         names.add(material.toString());
         names.add(material.toString().toLowerCase());
 
+        if (materialName.contains("_")) { // Prefix wildcarding for shulker boxes & gates
+            int i = materialName.indexOf("_") + 1;
+            while (i > 0) {
+                names.add("*_" + materialName.substring(i));
+                names.add("*_" + materialName.substring(i).toLowerCase());
+                i = materialName.indexOf("_", i) + 1;
+            }
+        }
+
         // Add the wildcards last so it can be overriden
         names.add("*");
 
@@ -1640,6 +1671,7 @@ public class LWC {
 
             if (temp != null && !temp.isEmpty()) {
                 value = temp;
+                break;
             }
         }
 


### PR DESCRIPTION
Previously material types that had multiple underscores (e.g. light_gray_shulker_box) were not properly supported by wildcards (e.g. *_shulker_box).
Also added the data byte to all possible config entries and not just the human readable material name. Ideally this config loading should use a smarter matcher in order to be able to do actual state/BlockData matching.
Also overriding the * wildcard with a more specific one wasn't possible so the * wildcard was moved below and the configuration resolver now actually breaks once it finds a value instead of overwriting it with a less specific one.