### PR TITLE
Remove Stacktrace when FactionsUUID hook fails

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -104,6 +104,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.*;
+import java.util.logging.Level;
 
 public class LWC {
 
@@ -1824,10 +1825,10 @@ public class LWC {
             try {
                 registerModule(new Factions());
             } catch (NoClassDefFoundError e) {
-                this.log("Failed to hook into Factions!");
+                plugin.getLogger().warning("Failed to hook into Factions!");
                 this.log("Please make sure you are using an updated version of FactionsUUID.");
                 this.log("https://www.spigotmc.org/resources/factionsuuid.1035/");
-                e.printStackTrace();
+                plugin.getLogger().log(Level.FINE, "Unable to find necessary FactionsUUID classes:", e);
             }
         }
     }


### PR DESCRIPTION
Print "failed to hook" message as warning (because it MAY be an issue for the admins)
Keep the stacktrace at a lower log level (in case debugging is needed)
As per issue #106 