### PR TITLE
Properly check connection validity

### DIFF
--- a/src/main/java/com/griefcraft/sql/Database.java
+++ b/src/main/java/com/griefcraft/sql/Database.java
@@ -202,7 +202,7 @@ public abstract class Database {
      * @return if the connection was successful
      */
     public boolean connect() throws Exception {
-        if (connection != null) {
+        if (connection != null && !connection.isClosed() && connection.isValid(1)) {
             return true;
         }
 
@@ -242,7 +242,6 @@ public abstract class Database {
             connection = driver.connect("jdbc:" + currentType.toString().toLowerCase() + ":" + getDatabasePath(),
                     properties);
             connected = true;
-//			setAutoCommit(true);
             return true;
         } catch (SQLException e) {
             log("Failed to connect to " + currentType + ": " + e.getErrorCode() + " - " + e.getMessage());


### PR DESCRIPTION
Fixes #115.

About the issue:
autoReconnect is not a panacea, on the contrary it's quite dumb:
See MySQL connector [docs](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html#autoReconnect):
> If enabled the driver will throw an exception for a queries issued on a stale or dead connection, which belong to the current transaction, but will attempt reconnect before the next query issued on the connection in a new transaction. The use of this feature is not recommended, because it has side effects related to session state and data consistency when applications don't handle SQLExceptions properly, and is only designed to be used when you are unable to configure your application to handle SQLExceptions resulting from dead and stale connections properly.

Proposed changes do work, I've used the exact same code with my plugins back in time when other plugins like LWC did spam my logs after some inactivity, and this code never failed me.

Notes:
- Database class had CRLF line endings while all other files have LF endings. So I took a liberty to fix that. (Actually my IDE did this). So please view diff via something which can ignore line endings.
- That auto commit call line is commented out since 2018, so... I took a liberty 🙂