### PR TITLE
use persistent data container to save protection info

### DIFF
--- a/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
@@ -133,8 +133,8 @@ public class LWCBlockListener implements Listener {
             // we don't have the block id of the block before it
             // so we have to do some raw lookups (these are usually cache hits
             // however, at least!)
-            Protection protection = lwc.getPhysicalDatabase().loadProtection(block.getWorld().getName(), block.getX(),
-                    block.getY(), block.getZ());
+            // HOOK: getPersistentDataContainer()
+            Protection protection = lwc.getPhysicalDatabase().loadProtection(block);
             if (protection != null) {
                 event.setCancelled(true);
             }
@@ -520,9 +520,8 @@ public class LWCBlockListener implements Listener {
             if (blockId < 0) {
                 return;
             }
-            Protection protection = lwc.getPhysicalDatabase().registerProtection(blockId, type,
-                    block.getWorld().getName(), player.getUniqueId().toString(), "", block.getX(), block.getY(),
-                    block.getZ());
+            // HOOK: save
+            Protection protection = lwc.getPhysicalDatabase().registerProtection(blockState, type.ordinal(), player.getUniqueId().toString(), "");
 
             if (!Boolean.parseBoolean(lwc.resolveProtectionConfiguration(block, "quiet"))) {
                 lwc.sendLocaleToActionBar(player, "protection.onplace.create.finalize", "type",
@@ -533,6 +532,7 @@ public class LWCBlockListener implements Listener {
             if (protection != null) {
                 lwc.getModuleLoader().dispatchEvent(new LWCProtectionRegistrationPostEvent(protection));
             }
+
             protection.saveNow();
         } catch (Exception e) {
             lwc.sendLocale(player, "protection.internalerror", "id", "PLAYER_INTERACT");

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -76,6 +76,7 @@ import com.griefcraft.scripting.event.LWCReloadEvent;
 import com.griefcraft.scripting.event.LWCSendLocaleEvent;
 import com.griefcraft.sql.Database;
 import com.griefcraft.sql.PhysDB;
+import com.griefcraft.sql.PersistentDB;
 import com.griefcraft.util.*;
 import com.griefcraft.util.config.Configuration;
 import com.griefcraft.util.matchers.DoubleChestMatcher;
@@ -172,6 +173,11 @@ public class LWC {
      */
     private boolean alternativeHoppers;
 
+    /**
+     * helper for PersistentDataContainer
+     */
+    public PersistentDB persistentDB;
+
     public LWC(LWCPlugin plugin) {
         this.plugin = plugin;
         LWC.instance = this;
@@ -180,6 +186,7 @@ public class LWC {
         protectionCache = new ProtectionCache(this);
         backupManager = new BackupManager();
         moduleLoader = new ModuleLoader(this);
+        persistentDB = new PersistentDB(plugin);
     }
 
     /**
@@ -589,6 +596,12 @@ public class LWC {
         }
 
         physicalDatabase = null;
+
+
+        if (persistentDB != null) {
+            persistentDB.dispose();
+        }
+
 
         // Clean ourselves up
         instance = null;
@@ -2125,6 +2138,13 @@ public class LWC {
      */
     public PhysDB getPhysicalDatabase() {
         return physicalDatabase;
+    }
+
+    /**
+     * @return PersistentDataContainer helper object
+     */
+    public PersistentDB getPersistentDB() {
+        return persistentDB;
     }
 
     /**

--- a/src/main/java/com/griefcraft/sql/PersistentDB.java
+++ b/src/main/java/com/griefcraft/sql/PersistentDB.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 cs8425. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and contributors and should not be interpreted as representing official policies,
+ * either expressed or implied, of anybody else.
+ */
+
+package com.griefcraft.sql;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.persistence.PersistentDataHolder;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.ConfigurationSection;
+
+//import java.util.ArrayList;
+//import java.util.Date;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+//import java.util.List;
+//import java.util.UUID;
+
+public class PersistentDB {
+	/**
+	 * NamespacedKeys for PersistentDataContainer
+	 */
+	private final Map<String, NamespacedKey> nKey = new HashMap<>();
+
+	/**
+	 * ID for ContainerID
+	 */
+	private File counterFile;
+	private YamlConfiguration config;
+	private int counter;
+
+	public PersistentDB(JavaPlugin plugin) {
+		nKey.put("id", new NamespacedKey(plugin, "id"));
+		nKey.put("type", new NamespacedKey(plugin, "type"));
+		nKey.put("owner", new NamespacedKey(plugin, "owner"));
+		nKey.put("password", new NamespacedKey(plugin, "pwd"));
+		nKey.put("date", new NamespacedKey(plugin, "date"));
+		nKey.put("last_accessed", new NamespacedKey(plugin, "last_accessed"));
+		nKey.put("JSON_data", new NamespacedKey(plugin, "data"));
+
+		counterFile = new File(plugin.getDataFolder() + File.separator + "pdc.yml");
+		if(!counterFile.exists()){
+			try{
+				counterFile.createNewFile();
+			}catch (IOException e){
+				e.printStackTrace();
+			}
+		}
+		config = YamlConfiguration.loadConfiguration(counterFile);
+		counter = config.getInt("sn", 0);
+	}
+
+	public synchronized int getID() {
+		counter -= 1;
+		return counter;
+	}
+	public synchronized void dispose() {
+		config.set("sn", counter);
+		try{
+			config.save(counterFile);
+		}catch(IOException e){
+			e.printStackTrace();
+		}
+	}
+
+	public boolean readFrom(PersistentDataContainer dc, ProtectionInfo out) {
+		out.protectionId = dc.getOrDefault(nKey.get("id"), PersistentDataType.INTEGER, null);
+		if (out.protectionId == null) return false;
+
+		out.type = dc.getOrDefault(nKey.get("type"), PersistentDataType.INTEGER, null);
+		if (out.type == null) return false;
+
+		out.owner = dc.getOrDefault(nKey.get("owner"), PersistentDataType.STRING, null);
+		if (out.owner == null) return false;
+
+		out.password = dc.getOrDefault(nKey.get("password"), PersistentDataType.STRING, null);
+		if (out.password == null) return false;
+
+		out.date = dc.getOrDefault(nKey.get("date"), PersistentDataType.STRING, null);
+		if (out.date == null) return false;
+
+		out.lastAccessed = dc.getOrDefault(nKey.get("last_accessed"), PersistentDataType.LONG, null);
+		if (out.lastAccessed == null) return false;
+
+		out.data = dc.getOrDefault(nKey.get("JSON_data"), PersistentDataType.STRING, null);
+		if (out.data == null) return false;
+
+		return true;
+	}
+
+	public boolean saveTo(PersistentDataContainer dc, ProtectionInfo info) {
+		dc.set(nKey.get("id"), PersistentDataType.INTEGER, info.protectionId);
+		dc.set(nKey.get("type"), PersistentDataType.INTEGER, info.type);
+		dc.set(nKey.get("owner"), PersistentDataType.STRING, info.owner);
+		dc.set(nKey.get("password"), PersistentDataType.STRING, info.password);
+		dc.set(nKey.get("date"), PersistentDataType.STRING, info.date);
+		dc.set(nKey.get("last_accessed"), PersistentDataType.LONG, info.lastAccessed);
+		dc.set(nKey.get("JSON_data"), PersistentDataType.STRING, info.data);
+		return true;
+	}
+
+	public boolean clear(PersistentDataContainer dc) {
+		dc.remove(nKey.get("id"));
+		dc.remove(nKey.get("type"));
+		dc.remove(nKey.get("owner"));
+		dc.remove(nKey.get("password"));
+		dc.remove(nKey.get("date"));
+		dc.remove(nKey.get("last_accessed"));
+		dc.remove(nKey.get("JSON_data"));
+		return true;
+	}
+
+	public static class ProtectionInfo {
+		public Integer protectionId; // id
+		public Integer type; // type
+		public String owner; // owner
+		public String password; // password
+		public String date; // date
+		public Long lastAccessed; // last_accessed
+		public String data; // JSON_data
+	}
+}
+

--- a/src/main/java/com/griefcraft/util/ProtectionFinder.java
+++ b/src/main/java/com/griefcraft/util/ProtectionFinder.java
@@ -303,7 +303,8 @@ public class ProtectionFinder {
             return Result.E_NOT_FOUND;
         }
 
-        Protection protection = lwc.getPhysicalDatabase().loadProtection(block.getWorld().getName(), block.getX(), block.getY(), block.getZ());
+        // HOOK: getPersistentDataContainer()
+        Protection protection = lwc.getPhysicalDatabase().loadProtection(block);
 
         if (protection != null) {
             if (protection.getProtectionFinder() == null) {


### PR DESCRIPTION
As title,
this PR try to save protection block info into `org.bukkit.persistence.PersistentDataContainer`,
then we can reduce some SQLite/RDBMS usage.
Maybe we can even drop RDBMS dependency if only want the 'protection part'...?