### PR TITLE
Updates Towny support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.95.1.0</version>
+            <version>0.96.7.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>com.palmergames.bukkit.towny</groupId>
+            <groupId>com.github.TownyAdvanced</groupId>
             <artifactId>Towny</artifactId>
             <version>0.96.7.0</version>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             <id>glaremasters-repo</id>
             <url>https://repo.glaremasters.me/repository/public/</url>
         </repository>
+	    <repository>
+	        <id>jitpack.io</id>
+	        <url>https://jitpack.io</url>
+	    </repository>
     </repositories>
     <dependencies>
         <dependency>

--- a/src/config/towny.yml
+++ b/src/config/towny.yml
@@ -8,3 +8,5 @@ towny:
         plotClear: false
         # Should LWC remove protections when the town is unclaimed?
         townUnclaim: false
+        # Should LWC remove protections when a town goes to Ruin?
+        townRuin: false


### PR DESCRIPTION
- Bump Towny version in pom to 0.96.7.0.
- Replace call to deprecated TownUnclaimEvent.
- Add test to TOWN permission type access for player-owned-plots.
- Add TownRuinEvent listener.
  - When enabled in the towny.yml, towns which fall to ruin can lose
their protections.
- Updated towns.yml with above ruin feature (I'm guessing admins will
need to wipe their towns.yml.)
- Reduce overall imports in Towny.java and use Towny's API in smarter
ways reducing possible exceptions.