### PR TITLE
Remove footgun with primary key automatically setting autoincrement.

### DIFF
--- a/src/main/java/com/griefcraft/sql/Column.java
+++ b/src/main/java/com/griefcraft/sql/Column.java
@@ -96,7 +96,6 @@ class Column {
 
     public void setPrimary(boolean primary) {
         this.primary = primary;
-        autoIncrement = primary;
     }
 
     public void setTable(Table table) {

--- a/src/main/java/com/griefcraft/sql/PhysDB.java
+++ b/src/main/java/com/griefcraft/sql/PhysDB.java
@@ -286,6 +286,7 @@ public class PhysDB extends Database {
             column = new Column("id");
             column.setType("INTEGER");
             column.setPrimary(true);
+            column.setAutoIncrement(true);
             protections.add(column);
 
             column = new Column("owner");
@@ -342,6 +343,7 @@ public class PhysDB extends Database {
             column = new Column("id");
             column.setType("INTEGER");
             column.setPrimary(true);
+            column.setAutoIncrement(true);
             history.add(column);
 
             column = new Column("protectionId");
@@ -386,7 +388,6 @@ public class PhysDB extends Database {
             column = new Column("name");
             column.setType("VARCHAR(40)");
             column.setPrimary(true);
-            column.setAutoIncrement(false);
             internal.add(column);
 
             column = new Column("value");
@@ -399,6 +400,7 @@ public class PhysDB extends Database {
             column = new Column("id");
             column.setType("INTEGER");
             column.setPrimary(true);
+            column.setAutoIncrement(true);
             column.setAutoIncrement(false);
             blocks.add(column);
 

--- a/src/main/java/com/griefcraft/sql/PhysDB.java
+++ b/src/main/java/com/griefcraft/sql/PhysDB.java
@@ -400,8 +400,6 @@ public class PhysDB extends Database {
             column = new Column("id");
             column.setType("INTEGER");
             column.setPrimary(true);
-            column.setAutoIncrement(true);
-            column.setAutoIncrement(false);
             blocks.add(column);
 
             column = new Column("name");


### PR DESCRIPTION
They are two separate concepts, and it shouldn't be taken for granted
that you need to unset the autoincrement after setting isPrimary to
true for non integer datatypes. Especially because this works just fine
in sqlite, but not in mysql, meaning that it's likely to work just fine
in testing, but not in prod.