### PR TITLE
Add protection type FACTION

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -72,6 +72,7 @@ import com.griefcraft.modules.unlock.UnlockModule;
 import com.griefcraft.scripting.Module;
 import com.griefcraft.scripting.ModuleLoader;
 import com.griefcraft.scripting.event.LWCAccessEvent;
+import com.griefcraft.scripting.event.LWCFactionMatcherEvent;
 import com.griefcraft.scripting.event.LWCReloadEvent;
 import com.griefcraft.scripting.event.LWCSendLocaleEvent;
 import com.griefcraft.sql.Database;
@@ -791,6 +792,17 @@ public class LWC {
                             .ordinal()) {
                         return true;
                     }
+                }
+
+                break;
+            case FACTION:
+                // call the sameFaction hook
+                LWCFactionMatcherEvent event = new LWCFactionMatcherEvent(player, protection);
+                moduleLoader.dispatchEvent(event);
+
+                // Is the player in the same faction as the protection owner?
+                if (event.isSameFaction()) {
+                    return true;
                 }
 
                 break;

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -110,6 +110,9 @@ public class LWCPlugin extends JavaPlugin {
             } else if (commandName.equals("cprivate") || commandName.equals("lock")) {
                 aliasCommand = "create";
                 aliasArgs = ("private " + argString).split(" ");
+            } else if (commandName.equals("cfaction")) {
+                aliasCommand = "create";
+                aliasArgs = ("faction " + argString).split(" ");
             } else if (commandName.equals("cdonation")) {
                 aliasCommand = "create";
                 aliasArgs = ("donation " + argString).split(" ");

--- a/src/main/java/com/griefcraft/model/Protection.java
+++ b/src/main/java/com/griefcraft/model/Protection.java
@@ -92,11 +92,9 @@ public class Protection {
         PRIVATE,
 
         /**
-         * The protection is only usable by players inside the same faction of the
-         * player who created it. Any Faction plugin can listen to the event and
-         * declare, whether this is the case or not.
+         * Reserved / unused, to keep ordinal order
          */
-        FACTION,
+        RESERVED1,
 
         /**
          * Reserved / unused, to keep ordinal order
@@ -111,7 +109,14 @@ public class Protection {
         /**
          * Allows players to look into but not take
          */
-        DISPLAY;
+        DISPLAY,
+
+        /**
+         * The protection is only usable by players inside the same faction of the
+         * player who created it. Any Faction plugin can listen to the event and
+         * declare, whether this is the case or not.
+         */
+        FACTION;
 
         /**
          * Match a protection type using its string form

--- a/src/main/java/com/griefcraft/model/Protection.java
+++ b/src/main/java/com/griefcraft/model/Protection.java
@@ -92,9 +92,11 @@ public class Protection {
         PRIVATE,
 
         /**
-         * Reserved / unused, to keep ordinal order
+         * The protection is only usable by players inside the same faction of the
+         * player who created it. Any Faction plugin can listen to the event and
+         * declare, whether this is the case or not.
          */
-        RESERVED1,
+        FACTION,
 
         /**
          * Reserved / unused, to keep ordinal order

--- a/src/main/java/com/griefcraft/modules/pluginsupport/Factions.java
+++ b/src/main/java/com/griefcraft/modules/pluginsupport/Factions.java
@@ -2,7 +2,9 @@ package com.griefcraft.modules.pluginsupport;
 
 import com.griefcraft.lwc.LWC;
 import com.griefcraft.scripting.JavaModule;
+import com.griefcraft.scripting.event.LWCFactionMatcherEvent;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
+import com.griefcraft.util.UUIDRegistry;
 import com.massivecraft.factions.Board;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.FactionsPlugin;
@@ -13,7 +15,10 @@ import com.massivecraft.factions.FPlayer;
 import com.massivecraft.factions.FPlayers;
 
 import java.util.Set;
+import java.util.UUID;
 
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.Plugin;
 
 public class Factions extends JavaModule {
@@ -98,5 +103,20 @@ public class Factions extends JavaModule {
         }
 
         return false;
+    }
+
+    public void onMatchingFaction(LWCFactionMatcherEvent event) {
+        FPlayer fPlayer = FPlayers.getInstance().getByPlayer(event.getPlayer());
+        UUID uuid = UUIDRegistry.getUUID(event.getProtection().getOwner());
+
+        if (uuid == null) {
+            return;
+        }
+
+        FPlayer owner = FPlayers.getInstance().getById(uuid.toString());
+
+        if (fPlayer.getFactionId().equals(owner.getFactionId())) {
+            event.setSameFaction(true);
+        }
     }
 }

--- a/src/main/java/com/griefcraft/scripting/JavaModule.java
+++ b/src/main/java/com/griefcraft/scripting/JavaModule.java
@@ -34,6 +34,7 @@ import com.griefcraft.scripting.event.LWCBlockInteractEvent;
 import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCDropItemEvent;
 import com.griefcraft.scripting.event.LWCEntityInteractEvent;
+import com.griefcraft.scripting.event.LWCFactionMatcherEvent;
 import com.griefcraft.scripting.event.LWCMagnetPullEvent;
 import com.griefcraft.scripting.event.LWCProtectionDestroyEvent;
 import com.griefcraft.scripting.event.LWCProtectionInteractEntityEvent;
@@ -132,4 +133,7 @@ public class JavaModule implements Module {
 
     }
 
+    public void onMatchingFaction(LWCFactionMatcherEvent event) {
+
+    }
 }

--- a/src/main/java/com/griefcraft/scripting/Module.java
+++ b/src/main/java/com/griefcraft/scripting/Module.java
@@ -34,6 +34,7 @@ import com.griefcraft.scripting.event.LWCBlockInteractEvent;
 import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCDropItemEvent;
 import com.griefcraft.scripting.event.LWCEntityInteractEvent;
+import com.griefcraft.scripting.event.LWCFactionMatcherEvent;
 import com.griefcraft.scripting.event.LWCMagnetPullEvent;
 import com.griefcraft.scripting.event.LWCProtectionDestroyEvent;
 import com.griefcraft.scripting.event.LWCProtectionInteractEntityEvent;
@@ -156,5 +157,7 @@ public interface Module {
     public void onMagnetPull(LWCMagnetPullEvent event);
 
     public void onRegisterEntity(LWCProtectionRegisterEntityEvent event);
+
+    public void onMatchingFaction(LWCFactionMatcherEvent event);
 
 }

--- a/src/main/java/com/griefcraft/scripting/ModuleLoader.java
+++ b/src/main/java/com/griefcraft/scripting/ModuleLoader.java
@@ -36,6 +36,7 @@ import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCDropItemEvent;
 import com.griefcraft.scripting.event.LWCEntityInteractEvent;
 import com.griefcraft.scripting.event.LWCEvent;
+import com.griefcraft.scripting.event.LWCFactionMatcherEvent;
 import com.griefcraft.scripting.event.LWCMagnetPullEvent;
 import com.griefcraft.scripting.event.LWCProtectionDestroyEvent;
 import com.griefcraft.scripting.event.LWCProtectionInteractEntityEvent;
@@ -150,7 +151,13 @@ public class ModuleLoader {
 
         MAGNET_PULL(1),
 
-        REGISTER_PROTECTION_ENTITY;
+        REGISTER_PROTECTION_ENTITY,
+
+        /**
+         * Called when a protection needs to be checked if a player is
+         * inside the same faction as the protection owner
+         */
+        FACTION_MATCHING(2);
 
         Event() {
         }
@@ -288,6 +295,8 @@ public class ModuleLoader {
                     event = Event.INTERACT_PROTECTION_ENTITY;
                 } else if (parameter == LWCProtectionRegisterEntityEvent.class) {
                     event = Event.REGISTER_PROTECTION_ENTITY;
+                } else if (parameter == LWCFactionMatcherEvent.class) {
+                    event = Event.FACTION_MATCHING;
                 }
 
                 // ok!
@@ -385,6 +394,8 @@ public class ModuleLoader {
                     module.onEntityInteractProtection((LWCProtectionInteractEntityEvent) event);
                 } else if (type == Event.REGISTER_PROTECTION_ENTITY) {
                     module.onRegisterEntity((LWCProtectionRegisterEntityEvent) event);
+                } else if (type == Event.FACTION_MATCHING) {
+                    module.onMatchingFaction((LWCFactionMatcherEvent) event);
                 }
             }
         } catch (Throwable throwable) {

--- a/src/main/java/com/griefcraft/scripting/event/LWCFactionMatcherEvent.java
+++ b/src/main/java/com/griefcraft/scripting/event/LWCFactionMatcherEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2011 Tyler Blair. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and contributors and should not be interpreted as representing official policies,
+ * either expressed or implied, of anybody else.
+ */
+
+package com.griefcraft.scripting.event;
+
+import com.griefcraft.model.Protection;
+import com.griefcraft.scripting.ModuleLoader;
+import org.bukkit.entity.Player;
+
+public class LWCFactionMatcherEvent extends LWCPlayerEvent {
+
+    /**
+     * The protection they are requesting
+     */
+    private final Protection protection;
+
+    /**
+     * Whether the players are in the same faction or not
+     */
+    private boolean sameFaction;
+
+    public LWCFactionMatcherEvent(Player player, Protection protection) {
+        super(ModuleLoader.Event.FACTION_MATCHING, player);
+
+        this.protection = protection;
+        this.sameFaction = false;
+    }
+
+    public Protection getProtection() {
+        return protection;
+    }
+
+    public boolean isSameFaction() {
+        return sameFaction;
+    }
+
+    public void setSameFaction(boolean sameFaction) {
+        this.sameFaction = sameFaction;
+    }
+}


### PR DESCRIPTION
The protection type FACTION allows the player to limit the access only to players inside the protection owner's faction. Matching two factions occurs through the LWCFactionMatcherEvent. Modules can listen to the event and override the matching boolean, to decide whether the access should be granted or not.