### PR TITLE
Update lwc_es.properties

### DIFF
--- a/src/lang/lwc_es.properties
+++ b/src/lang/lwc_es.properties
@@ -1,5 +1,5 @@
 ## LWC 4.5.0 | EntityLWC 1.8.6
-## Traducido originalmente por: Raul Martinez (RME) | Actualizado por: C4BR3R4es y Miguel-Dorta
+## Traducido originalmente por: Raul Martinez (RME) | Actualizado por: C4BR3R4es, Miguel-Dorta y Jasper Lutz
 
 ##################
 ##    General   ##
@@ -10,8 +10,8 @@ public=Público
 private=Privado
 password=Contraseña
 status=Estado
-kick_trap=Trampa de Kickeo
-ban_trap=Trampa de Baneo
+kick_trap=Trampa de expulsión
+ban_trap=Trampa de veto
 
 # Yes/no response (mainly for /lwc info)
 yes=%dark_green%Si
@@ -70,9 +70,9 @@ protection.unregistered=%dark_red%%block% desbloqueado.
 
 # Enforce access to blocks
 protection.general.locked.password=\
-%dark_red%Este %block% esta bloqueado \n\
+%dark_red%Este %block% está bloqueado \n\
 %dark_red%Escribe %gold%%cunlock% <Contraseña>%dark_red% para desbloquearlo.
-protection.general.locked.private=%dark_red%Este %block% esta protegido con un hechizo mágico.
+protection.general.locked.private=%dark_red%Este %block% está protegido con un hechizo mágico.
 
 # Pending name
 protection.general.pending=%dark_red%Ya hay una acción pendiente.
@@ -94,7 +94,7 @@ protection.info.limits=%dark_aqua%Has usado%dark_red% %used%%dark_aqua% de%dark_
 # Flag
 protection.flag.invalidflag=%dark_red%La flag%white% %flag%%dark_red% no se ha encontrado.
 protection.flag.invalidtype=%dark_red%El tipo%white% %type%%dark_red% no es correcto.
-protection.flag.finalize=%dark_aqua%Golpea la protección para establecer la flag.
+protection.flag.finalize=%dark_aqua%Golpea la protección para establecer la bandera.
 
 # Modes - not yet supported
 
@@ -112,13 +112,13 @@ protection.remove.modes.finalize=Todos tus modos han sido desactivados.
 protection.menu.finalize=El tipo de menú ha cambiado a%dark_aqua% %style%
 
 # Unlock
-protection.unlock.nothingselected=%dark_red%No hay nada seleccionado. Toca antes una protección.
-protection.unlock.notpassword=%dark_red%¿Como has hecho eso?
+protection.unlock.nothingselected=%dark_red%No hay nada seleccionado. Selecciona antes una protección.
+protection.unlock.notpassword=%dark_red%¿Cómo has hecho eso?
 protection.unlock.password.valid=%dark_green%Contraseña correcta.
 protection.unlock.password.invalid=%dark_red%Contraseña incorrecta.
 
 # Modes
-protection.modes.disabled=%dark_red%Ese modo esta deshabilitado.
+protection.modes.disabled=%dark_red%Ese modo está deshabilitado.
 
 protection.modes.persist.finalize=\
 %dark_green%Tus comandos serán persistentes. \n\
@@ -146,17 +146,17 @@ protection.modes.dropxfer.status.inactive=%dark_aqua%La transferencia de objetos
 
 # Admin (large command set)
 
-protection.admin.noconsole=%dark_red%Comando no admitido en consola.
+protection.admin.noconsole=%dark_red%Comando no admitido en la consola.
 
 protection.admin.cleanup.start=\
 Tienes:%dark_green% %count%%white% protecciones. \n\
-%dark_red%Esto puede tardar tiempo, dependiendo del numero de protecciones.
+%dark_red%Esto puede tardar un rato, dependiendo del numero de protecciones.
 protection.admin.cleanup.noworld=%dark_red%Error:%white% El mundo %world% no existe
 protection.admin.cleanup.removednoexist=Eliminadas (no existentes): %protection%
 protection.admin.cleanup.removeddupe=Eliminadas (duplicadas): %protection%
 protection.admin.cleanup.complete=¡LWC ha eliminado%dark_green% %count%%white% protecciones en%dark_green% %seconds%%white% segundos!
 
-protection.find.invalidpage=%dark_red%¡Numero de página incorrecto!
+protection.find.invalidpage=%dark_red%¡Número de página incorrecto!
 protection.find.currentpage=%dark_red%Página:%white% %page%
 protection.find.nextpage=Siguiente Página:%dark_red% /lwc admin find %player% %page%
 # hard to read :-), just "showing" and "total"
@@ -166,7 +166,7 @@ protection.find.showing=\
 
 protection.admin.forceowner.finalize=%dark_aqua%Golpea la protección para cambiar el propietario:%white% %player%
 
-protection.admin.remove.invalidid=%dark_red%ID erróneo.
+protection.admin.remove.invalidid=%dark_red%ID inválido.
 protection.admin.remove.finalize=%dark_green%Protección eliminada correctamente.
 
 protection.admin.view.noexist=%dark_red%¡Esta protección no existe!
@@ -196,7 +196,7 @@ protection.admin.clear.protections=%dark_green%Se han eliminado todas las protec
 protection.admin.clear.rights=%dark_green%Se han eliminado todos los permisos.
 
 # get limits
-protection.getlimits.player=%dark_aqua%%name% esta usando%dark_red% %used%%dark_aqua% de%dark_green% %quota%%dark_aqua% protecciones máximas.
+protection.getlimits.player=%dark_aqua%%name% está usando%dark_red% %used%%dark_aqua% de%dark_green% %quota%%dark_aqua% protecciones máximas.
 protection.getlimits.group=%dark_aqua%%name% puede tener%dark_green% %quota%%dark_aqua% protecciones.
 
 # expiration
@@ -226,11 +226,11 @@ protection.interact.rights.remove.region=%dark_green%Permisos eliminados de la r
 protection.onplace.create.finalize=%dark_green%Se ha creado el %block% %type% correctamente.
 
 # Flag
-protection.interact.flag.add=%dark_green%La flag%dark_aqua% %flag%%dark_green% ha sido activada (on).
-protection.interact.flag.remove=%dark_red%La flag%dark_aqua% %flag%%dark_red% ha sido desactivada (off).
+protection.interact.flag.add=%dark_green%La bandera%dark_aqua% %flag%%dark_green% ha sido activada
+protection.interact.flag.remove=%dark_red%La bandera%dark_aqua% %flag%%dark_red% ha sido desactivada
 
 # Creation
-protection.interact.create.password=%dark_aqua%Por comodidad, no tendrás que introducir la contraseña hasta que vuelvas a entrar.
+protection.interact.create.password=%dark_aqua%Por comodidad, no tendrás que introducir la contraseña hasta que vuelvas a iniciar sesión.
 protection.interact.create.finalize=%dark_green%Protección creada con éxito.
 
 # Removal
@@ -252,10 +252,10 @@ Datos brutos de la protección: \n\
 # Drop transfer
 protection.interact.dropxfer.notprotected=\
 %dark_red%Solo puedes seleccionar un cofre para la transferencia de objetos. \n\
-%dark_red%Usa "/lwc mode droptransfer select" para intentar de nuevo. \n\
+%dark_red%Ejecuta "/lwc mode droptransfer select" para intentar de nuevo. \n\
 protection.interact.dropxfer.noaccess=\
 %dark_red%No puedes utilizar este cofre para transferir objetos. \n\
-%dark_red%Si el cofre tiene contraseña primero tienes que eliminarla. \n\
+%dark_red%Si el cofre tiene contraseña, primero tendrás que eliminarla. \n\
 %dark_red%Usa "/lwc mode droptransfer select" para intentar de nuevo
 protection.interact.dropxfer.notchest=%dark_red%Primero tienes que seleccionar un cofre.
 protection.interact.dropxfer.finalize=%dark_green%El cofre se ha configurado para transferir objetos.
@@ -286,8 +286,8 @@ help.basic=\
 \n\
 %dark_green%Bienvenido al mod de protección LWC\n\
 \n\
-%white%/cprivate %dark_aqua%Crear una protección Privada \n\
-%white%/cpublic %dark_aqua%Crear una protección Pública \n\
+%white%/cprivate %dark_aqua%Crear una protección privada \n\
+%white%/cpublic %dark_aqua%Crear una protección pública \n\
 %white%/cdonation %dark_aqua%Crear un cofre de donaciones \n\
 %white%/cpassword %aqua%<Contraseña> %dark_aqua%Crear una protección con contraseña \n\
 %white%/cmodify %dark_aqua%Modificar una protección existente \n\
@@ -304,14 +304,14 @@ help.creation=\
 \n\
 %dark_green%Protección LWC \n\
 \n\
-%white%%cpublic% %gold%Crear una protección Pública \n\
-%dark_aqua%Cualquier jugador puede usar una protección Pública, pero no puede protegerla \n\
+%white%%cpublic% %gold%Crear una protección pública \n\
+%dark_aqua%Cualquier jugador puede usar una protección pública, pero no puede protegerla \n\
 \n\
 %white%%cpassword% <Contraseña> %gold%Contraseña de protección \n\
 %dark_aqua%Cada vez que inicias sesión tienes que introducir la contraseña para poder usar la protección \n\
 %dark_aqua%(¡si alguien conoce la contraseña también puede usar la protección!) \n\
 \n\
-%white%%cprivate% %gold%Crear una protección Privada \n\
+%white%%cprivate% %gold%Crear una protección privada \n\
 %dark_aqua%Privado significa privado, pero también puedes permitir que otros usuarios o grupos tengan acceso. Esto se hace después de añadir la "privatización". \n\n\
 %white%Ejemplo: \n\
 %dark_aqua%%cprivate% NombreUsuario g:NombreGrupo OtroJugador \n\
@@ -349,13 +349,13 @@ help.admin=\
 /lwc admin report%dark_aqua% Ver el informa de ejecución de LWC \n\
 \n\
 /lwc admin convert%dark_aqua% Convertir la base de datos de otro plugin a LWC \n\
-/lwc admin clear%aqua% <protections|rights>%dark_red% ¡Atención! Usar este comando es PELIGROSO y las acciones no se pueden revertir!!
+/lwc admin clear%aqua% <protections|rights>%dark_red% ¡Atención! ¡¡¡Usar este comando es PELIGROSO y las acciones no se pueden revertir!!!
 
 # /lwc flag
 help.flags=\
 \n\
-Uso de flags: \n\
-%dark_aqua%  Redstone:%white% Si está en "on", la redstone %redstone%%white% puede abrir las puertas.
+Uso de banderas: \n\
+%dark_aqua%  Redstone:%white% Si está en "on", la redstone %redstone%%white% podrá abrir las puertas.
 
 # redstone specific flags, depends on deny-redstone is enabled/disabled
 help.flags.redstone.allow=%dark_green%puede
@@ -412,7 +412,7 @@ protection.create.status.notsign=%dark_red%Esta protección necesita un Cartel.
 ## 3.10  ##
 ###########
 
-protection.doors.open=%dark_green%La puerta cruje al abrirse....
+protection.doors.open=%dark_green%La puerta cruje al abrirse...
 protection.doors.close=%dark_green%¡La puerta da un golpe al cerrarse!
 
 ##########
@@ -439,7 +439,7 @@ lwc.playernotfound=%dark_red%No se ha encontrado el Jugador.
 lwc.invalidprotectionid=%dark_red%El ID de la protección es errónea.
 lwc.playerloggedout=%dark_red%¡El jugador se ha ido!
 lwc.onlyrealplayers=%dark_red%El comando solo lo pueden utilizar jugadores reales :-)
-lwc.invalidworld=%dark_red%¡Mundo no válido!
+lwc.invalidworld=%dark_red%¡Mundo inválido!
 lwc.noresults=%dark_red%No se han encontrado resultados.
 lwc.nolongerexists=%dark_red%¡La protección ya no existe!
 lwc.invalidstyle=%dark_red%Tipo erróneo.
@@ -461,7 +461,7 @@ lwc.job.waiting=%dark_green%La tarea %name% está a la espera de ser ejecutada.
 lwc.job.nextrun=%dark_green%La tarea %name% será ejecutada en: %time%
 lwc.job.setarguments=%dark_green%La tarea %name% tiene ahora el argumento: "%arguments"
 
-lwc.setup.database.invalid=%dark_red%Tipo de base de datos no válida.
+lwc.setup.database.invalid=%dark_red%Tipo de base de datos inválida.
 lwc.setup.database.success=%dark_green%La base de datos se ha convertido correctamente en %type%.
 lwc.setup.database.failure=%dark_red%Error al convertir la base de datos en %type%. Por favor, comprueba si en la consola han aparecido errores.
 
@@ -532,7 +532,7 @@ lwc.devmode.lost=%dark_green%Se te ha desactivado el Modo Desarrollador.
 lwc.devmode.nodevmode=%dark_red%El jugador no tiene activado el Modo Desarrollador.
 lwc.devmode.permissionsmode=%dark_green%Permiso establecido a:%yellow% %mode%
 
-lwc.easynotify.redstone=%dark_red%Note:%white% La redstone actualmente está permitida en esta protección. Para desactivar la redstone, usa%dark_green% /credstone on
+lwc.easynotify.redstone=%dark_red%Note:%white% La redstone actualmente está permitida en esta protección. Para desactivarla, ejecuta%dark_green% /credstone on
 
 lwc.fix.fixed=%dark_green%¡%block% solucionado!
 lwc.fix.clickblock=%dark_green%Clic sobre un bloque para realizar el hechizo mágico.


### PR DESCRIPTION
"Kickeo" and "baneo" do not exist in the Spanish language, "expulsión" and "veto" do.
"Flag" also doesn't exist, "bandera" would be a correct translation. 
Added some missing tildes.
"no válido/a" is just "inválido/a" but unnecessarily over-complicated.
Fix some inconsistencies.
Fix some minor problems and improve readability.