### PR TITLE
Add a Check if the player is accessible on EntityChangeBlockEvent.

### DIFF
--- a/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
@@ -155,6 +155,16 @@ public class LWCBlockListener implements Listener {
         }
 
         Protection protection = lwc.findProtection(block);
+
+        if (event.getEntity() instanceof Player) {
+            Player player = (Player) event.getEntity();
+            boolean canAccess = lwc.canAccessProtection(player, protection);
+            if (!canAccess) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+
         if (protection != null) {
             event.setCancelled(true);
         }


### PR DESCRIPTION
When the player uses the composter, the EntityChangeBlockEvent fires, but is canceled because the player's accessibility has not been checked.


![ezgif-5-e9a28c2685](https://user-images.githubusercontent.com/12862158/198050074-546b9615-07f2-477f-94e1-edd248222328.gif)

```
> lwc admin version
[23:09:31 INFO]: LWC
[23:09:31 INFO]: https://www.spigotmc.org/resources/lwc-extended.69551/
[23:09:31 INFO]: Main plugin: 2.2.8-f367129/
> version
[23:09:39 INFO]: Checking version, please wait...
[23:09:40 INFO]: This server is running Paper version git-Paper-237 (MC: 1.19.2) (Implementing API version 1.19.2-R0.1-SNAPSHOT) (Git: 25cd3ee)
You are running the latest version
```