### PR TITLE
New protection type `supply`

### DIFF
--- a/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
@@ -385,7 +385,8 @@ public class LWCBlockListener implements Listener {
             for (Protection protection : lwc.findAdjacentProtectionsOnAllSides(block)) {
                 if (protection != null) {
                     if (!lwc.canAccessProtection(player, protection)
-                            || ((protection.getType() == Protection.Type.DONATION || protection.getType() == Protection.Type.DISPLAY)
+                            || ((protection.getType() == Protection.Type.DONATION || protection.getType() == Protection.Type.DISPLAY
+                            || protection.getType() == Protection.Type.SUPPLY)
                             && !lwc.canAdminProtection(player, protection))) {
                         // they can't access the protection ..
                         event.setCancelled(true);
@@ -470,7 +471,7 @@ public class LWCBlockListener implements Listener {
         String autoRegisterType = lwc.resolveProtectionConfiguration(block, "autoRegister");
 
         // is it auto protectable?
-        if (!autoRegisterType.equalsIgnoreCase("private") && !autoRegisterType.equalsIgnoreCase("public") && !autoRegisterType.equalsIgnoreCase("donation") && !autoRegisterType.equalsIgnoreCase("display")) {
+        if (!autoRegisterType.equalsIgnoreCase("private") && !autoRegisterType.equalsIgnoreCase("public") && !autoRegisterType.equalsIgnoreCase("donation") && !autoRegisterType.equalsIgnoreCase("display") && !autoRegisterType.equalsIgnoreCase("supply")) {
             return;
         }
 

--- a/src/main/java/com/griefcraft/listeners/LWCEntityListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCEntityListener.java
@@ -239,7 +239,7 @@ public class LWCEntityListener implements Listener {
         String autoRegisterType = lwc.resolveProtectionConfiguration(entity.getType(), "autoRegister");
 
         // is it auto protectable?
-        if (!autoRegisterType.equalsIgnoreCase("private") && !autoRegisterType.equalsIgnoreCase("public") && !autoRegisterType.equalsIgnoreCase("donation") && !autoRegisterType.equalsIgnoreCase("display") && !autoRegisterType.equalsIgnoreCase("supply")) {
+        if (!autoRegisterType.equalsIgnoreCase("private") && !autoRegisterType.equalsIgnoreCase("public") && !autoRegisterType.equalsIgnoreCase("donation") && !autoRegisterType.equalsIgnoreCase("display")) {
             return;
         }
 

--- a/src/main/java/com/griefcraft/listeners/LWCEntityListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCEntityListener.java
@@ -239,7 +239,7 @@ public class LWCEntityListener implements Listener {
         String autoRegisterType = lwc.resolveProtectionConfiguration(entity.getType(), "autoRegister");
 
         // is it auto protectable?
-        if (!autoRegisterType.equalsIgnoreCase("private") && !autoRegisterType.equalsIgnoreCase("public") && !autoRegisterType.equalsIgnoreCase("donation")) {
+        if (!autoRegisterType.equalsIgnoreCase("private") && !autoRegisterType.equalsIgnoreCase("public") && !autoRegisterType.equalsIgnoreCase("donation") && !autoRegisterType.equalsIgnoreCase("display") && !autoRegisterType.equalsIgnoreCase("supply")) {
             return;
         }
 

--- a/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -759,8 +759,8 @@ public class LWCPlayerListener implements Listener {
             return;
         }
 
-        // If it's not a donation or display chest, ignore it
-        if (protection.getType() != Protection.Type.DONATION && protection.getType() != Protection.Type.DISPLAY) {
+        // If it's not a donation, supply or display chest, ignore it
+        if (protection.getType() != Protection.Type.DONATION && protection.getType() != Protection.Type.DISPLAY && protection.getType() != Protection.Type.SUPPLY) {
             return;
         }
 
@@ -795,6 +795,25 @@ public class LWCPlayerListener implements Listener {
             // and left clicking)
             if (player.getInventory().getItemInMainHand() == null && (!event.isRightClick() && !event.isShiftClick())) {
                 return;
+            }
+        } else if (protection.getType() == Protection.Type.SUPPLY) {
+            // If it's not a container, we don't want it
+            if (event.getSlotType() != InventoryType.SlotType.CONTAINER && event.getSlotType() != InventoryType.SlotType.QUICKBAR) {
+                return;
+            }
+
+            InventoryAction action = event.getAction();
+
+            // Check if the slot is from top inventory
+            if (event.getRawSlot() < event.getView().getTopInventory().getSize()) {
+                if (action != InventoryAction.PLACE_ALL && action != InventoryAction.PLACE_SOME &&
+                        action != InventoryAction.PLACE_ONE && action != InventoryAction.SWAP_WITH_CURSOR) {
+                    return;
+                }
+            } else {
+                if (action != InventoryAction.MOVE_TO_OTHER_INVENTORY) {
+                    return;
+                }
             }
         }
 
@@ -867,8 +886,9 @@ public class LWCPlayerListener implements Listener {
             return;
         }
 
-        // If it's not a display chest, ignore it
-        if (protection.getType() != Protection.Type.DISPLAY) {
+        // If it's not a display chest or a supply chest and modified it, ignore it
+        if (protection.getType() != Protection.Type.DISPLAY && (protection.getType() != Protection.Type.SUPPLY ||
+                event.getRawSlots().stream().noneMatch(s -> s < event.getView().getTopInventory().getSize()))) {
             return;
         }
 

--- a/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -69,6 +69,7 @@ import org.bukkit.event.vehicle.VehicleDestroyEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Set;
@@ -759,7 +760,7 @@ public class LWCPlayerListener implements Listener {
             return;
         }
 
-        // If it's not a donation, supply or display chest, ignore it
+        // If it's not a donation, display or supply chest, ignore it
         if (protection.getType() != Protection.Type.DONATION && protection.getType() != Protection.Type.DISPLAY && protection.getType() != Protection.Type.SUPPLY) {
             return;
         }
@@ -797,22 +798,66 @@ public class LWCPlayerListener implements Listener {
                 return;
             }
         } else if (protection.getType() == Protection.Type.SUPPLY) {
-            // If it's not a container, we don't want it
-            if (event.getSlotType() != InventoryType.SlotType.CONTAINER && event.getSlotType() != InventoryType.SlotType.QUICKBAR) {
-                return;
-            }
+            // We check furnace fuel slot because furnace should supply only its result.
+            if (event.getSlotType() != InventoryType.SlotType.FUEL) {
 
-            InventoryAction action = event.getAction();
+                // Not furnace.
 
-            // Check if the slot is from top inventory
-            if (event.getRawSlot() < event.getView().getTopInventory().getSize()) {
-                if (action != InventoryAction.PLACE_ALL && action != InventoryAction.PLACE_SOME &&
-                        action != InventoryAction.PLACE_ONE && action != InventoryAction.SWAP_WITH_CURSOR) {
+                // We ignore those slot type:
+                // - outside of inventory ... nothing to check.
+                // - craft table result and furnace result... behaviour of these slots are like supply chest originally.
+                // - armor slot ... these slots should not appear when we see container inventory.
+                if (event.getSlotType() != InventoryType.SlotType.CONTAINER && event.getSlotType() != InventoryType.SlotType.QUICKBAR) {
                     return;
                 }
-            } else {
-                if (action != InventoryAction.MOVE_TO_OTHER_INVENTORY) {
-                    return;
+
+                boolean clickedTopInventory = isRawSlotInTopInventory(event.getView(), event.getRawSlot());
+
+                switch (event.getAction()) {
+
+                    // add or swap item in the slot.
+                    case PLACE_ALL:
+                    case PLACE_SOME:
+                    case PLACE_ONE:
+                    case SWAP_WITH_CURSOR:
+                        // check if a clicked slot is in top inventory.
+                        if (clickedTopInventory) {
+                            break;
+                        }
+                        return;
+
+                    // these actions can also swap items in supply chest.
+                    case HOTBAR_MOVE_AND_READD:
+                    case HOTBAR_SWAP:
+                        // check if a clicked slot is in top inventory and a hotbar item is empty.
+                        if (clickedTopInventory && event.getView().getBottomInventory().getItem(event.getHotbarButton()) != null) {
+                            break;
+                        }
+                        return;
+
+                    case MOVE_TO_OTHER_INVENTORY:
+                        // check if a clicked slot is in bottom inventory.
+                        if (!clickedTopInventory) {
+                            break;
+                        }
+                        return;
+
+                    // COLLECT_TO_CURSOR, PICKUP_ALL,
+                    // PICKUP_SOME, PICKUP_HALF,        -> players can pick up items from supply chest. ignore it.
+                    // PICKUP_ONE
+
+                    // DROP_ALL_SLOT, DROP_ONE_SLOT     -> players can drop items from supply chest. ignore it.
+
+                    // DROP_ALL_CURSOR, DROP_ONE_CURSOR -> these actions will not come here
+                    //                                     because OUTSIDE slot type is ignored above.
+
+                    // CLONE_STACK                      -> this action will not come here
+                    //                                     because CLONE_STACK is only for creative inventory.
+
+                    // NOTHING, UNKNOWN                 -> nothing to check.
+                    default:
+                        return;
+
                 }
             }
         }
@@ -886,19 +931,40 @@ public class LWCPlayerListener implements Listener {
             return;
         }
 
-        // If it's not a display chest or a supply chest and modified it, ignore it
-        if (protection.getType() != Protection.Type.DISPLAY && (protection.getType() != Protection.Type.SUPPLY ||
-                event.getRawSlots().stream().noneMatch(s -> s < event.getView().getTopInventory().getSize()))) {
-            return;
-        }
+        // If it's a display chest, check permission.
+        if (protection.getType() == Protection.Type.DISPLAY) {
+            // Can they admin it? (remove items/etc)
+            boolean canAdmin = lwc.canAdminProtection(player, protection);
 
-        // Can they admin it? (remove items/etc)
-        boolean canAdmin = lwc.canAdminProtection(player, protection);
+            // nope.avi
+            if (!canAdmin) {
+                event.setCancelled(true);
+            }
 
-        // nope.avi
-        if (!canAdmin) {
-            event.setCancelled(true);
+        // If it's a supply chest and player drag items on its slot, check permission.
+        } else if (protection.getType() == Protection.Type.SUPPLY &&
+                event.getRawSlots().stream().anyMatch(slot -> isRawSlotInTopInventory(event.getView(), slot))) {
+            // Can they admin it? (remove items/etc)
+            boolean canAdmin = lwc.canAdminProtection(player, protection);
+
+            // nope.avi
+            if (!canAdmin) {
+                event.setCancelled(true);
+            }
         }
+    }
+
+    /**
+     * Check if the rawSlot is smaller than top inventory size, that means specified slot is in the top inventory.
+     *
+     * @param view the inventory view.
+     * @param rawSlot the raw slot.
+     * @return true if specified raw slot is in the top inventory.
+     *
+     * @see InventoryView#getInventory(int)
+     */
+    private static boolean isRawSlotInTopInventory(InventoryView view, int rawSlot) {
+        return rawSlot < view.getTopInventory().getSize();
     }
 
 }

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -2308,7 +2308,7 @@ public class LWC {
             if (type == Protection.Type.PASSWORD) {
                 sendLocaleToActionBar(player, "protection.general.locked.password", "block", blockName, "owner",
                         protection.getOwner());
-            } else if (type == Protection.Type.PRIVATE || type == Protection.Type.DONATION || type == Protection.Type.SUPPLY) {
+            } else if (type == Protection.Type.PRIVATE || type == Protection.Type.DONATION) {
                 sendLocaleToActionBar(player, "protection.general.locked.private", "block", blockName,
                         "name", UUIDRegistry.isValidUUID(protection.getOwner()) ? UUIDRegistry.getName(UUID.fromString(protection.getOwner())) : protection.getOwner(),
                         "owner", protection.getOwner());

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -410,6 +410,7 @@ public class LWC {
             case PRIVATE:
             case DONATION:
             case DISPLAY:
+            case SUPPLY:
                 if (protection.isOwner(player)) {
                     return true;
                 }
@@ -704,7 +705,8 @@ public class LWC {
                 if (type == Protection.Type.PASSWORD) {
                     sendLocaleToActionBar(player, "protection.general.locked.password", "block", materialToString(block), "owner",
                             protection.getOwner());
-                } else if (type == Protection.Type.PRIVATE || type == Protection.Type.DONATION || type == Protection.Type.DISPLAY) {
+                } else if (type == Protection.Type.PRIVATE || type == Protection.Type.DONATION
+                        || type == Protection.Type.DISPLAY || type == Protection.Type.SUPPLY) {
                     sendLocaleToActionBar(player, "protection.general.locked.private", "block", materialToString(block),
                             "name", UUIDRegistry.isValidUUID(protection.getOwner()) ? UUIDRegistry.getName(UUID.fromString(protection.getOwner())) : protection.getOwner(),
                             "owner", protection.getOwner());
@@ -755,6 +757,7 @@ public class LWC {
             case PUBLIC:
             case DONATION:
             case DISPLAY:
+            case SUPPLY:
                 return true;
 
             case PASSWORD:
@@ -2305,7 +2308,7 @@ public class LWC {
             if (type == Protection.Type.PASSWORD) {
                 sendLocaleToActionBar(player, "protection.general.locked.password", "block", blockName, "owner",
                         protection.getOwner());
-            } else if (type == Protection.Type.PRIVATE || type == Protection.Type.DONATION) {
+            } else if (type == Protection.Type.PRIVATE || type == Protection.Type.DONATION || type == Protection.Type.SUPPLY) {
                 sendLocaleToActionBar(player, "protection.general.locked.private", "block", blockName,
                         "name", UUIDRegistry.isValidUUID(protection.getOwner()) ? UUIDRegistry.getName(UUID.fromString(protection.getOwner())) : protection.getOwner(),
                         "owner", protection.getOwner());

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -118,6 +118,9 @@ public class LWCPlugin extends JavaPlugin {
             } else if (commandName.equals("cdisplay")) {
                 aliasCommand = "create";
                 aliasArgs = ("display " + argString).split(" ");
+            } else if (commandName.equals("csupply")) {
+                aliasCommand = "create";
+                aliasArgs = ("supply " + argString).split(" ");
             } else if (commandName.equals("cmodify")) {
                 aliasCommand = "modify";
                 aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");

--- a/src/main/java/com/griefcraft/model/Protection.java
+++ b/src/main/java/com/griefcraft/model/Protection.java
@@ -109,7 +109,12 @@ public class Protection {
         /**
          * Allows players to look into but not take
          */
-        DISPLAY;
+        DISPLAY,
+
+        /**
+         * Allows players to take items from but not deposit
+         */
+        SUPPLY;
 
         /**
          * Match a protection type using its string form

--- a/src/main/java/com/griefcraft/modules/create/CreateModule.java
+++ b/src/main/java/com/griefcraft/modules/create/CreateModule.java
@@ -165,7 +165,8 @@ public class CreateModule extends JavaModule {
 
             lwc.sendLocale(player, "protection.interact.create.finalize");
             lwc.sendLocale(player, "protection.interact.create.password");
-        } else if (protectionType.equals("private") || protectionType.equals("donation") || protectionType.equals("display")) {
+        } else if (protectionType.equals("private") || protectionType.equals("donation")
+                || protectionType.equals("display") || protectionType.equals("supply")) {
             String[] rights = protectionData.split(" ");
             if (block instanceof EntityBlock) {
                 protection = physDb.registerProtection(EntityBlock.ENTITY_BLOCK_ID,

--- a/src/main/java/com/griefcraft/modules/info/InfoModule.java
+++ b/src/main/java/com/griefcraft/modules/info/InfoModule.java
@@ -73,7 +73,8 @@ public class InfoModule extends JavaModule {
         boolean canViewFullInfo = event.canAdmin() || lwc.isAdmin(player) || lwc.isMod(player);
 
         if (canViewFullInfo) {
-            if (protection.getType() == Protection.Type.PRIVATE || protection.getType() == Protection.Type.DONATION || protection.getType() == Protection.Type.DISPLAY) {
+            if (protection.getType() == Protection.Type.PRIVATE || protection.getType() == Protection.Type.DONATION
+                    || protection.getType() == Protection.Type.DISPLAY || protection.getType() == Protection.Type.SUPPLY) {
                 lwc.sendLocale(player, "lwc.acl", "size", protection.getPermissions().size());
                 int index = 0;
                 for (Permission permission : protection.getPermissions()) {

--- a/src/main/java/com/griefcraft/util/Completions.java
+++ b/src/main/java/com/griefcraft/util/Completions.java
@@ -14,7 +14,7 @@ public class Completions {
 
     private static final List<String> LWC = Arrays.asList("create", "modify", "default", "unlock", "info", "limits", "remove", "mode", "flag", "admin");
     private static final List<String> ADMIN = Arrays.asList("view", "find", "forceowner", "remove", "purge", "cleanup", "version", "update", "report", "clear");
-    private static final List<String> PROTECTION_TYPES = Arrays.asList("public", "private", "donation", "password", "display");
+    private static final List<String> PROTECTION_TYPES = Arrays.asList("public", "private", "donation", "password", "display", "supply");
     private static final List<String> TOGGLES = Arrays.asList("on", "off");
     private static final List<String> FLAGS = Arrays.asList("redstone", "magnet", "exemption", "autoclose", "allowexplosions", "hopper", "hopperin", "hopperout");
     private static final List<String> DROPTRANSFER = Arrays.asList("select", "on", "off", "status");

--- a/src/main/resources/config/core.yml
+++ b/src/main/resources/config/core.yml
@@ -135,7 +135,7 @@ protections:
     # If false, hoppers will be enabled by DEFAULT and /chopper on will disable hopper use on them
     denyHoppers: true
 
-    # Settable to private, public, donation, supply, or off. It defines what protections are registered as when you place them
+    # Settable to private, public, donation, display, supply, or off. It defines what protections are registered as when you place them
     # on the ground
     autoRegister: off
 

--- a/src/main/resources/config/core.yml
+++ b/src/main/resources/config/core.yml
@@ -135,7 +135,7 @@ protections:
     # If false, hoppers will be enabled by DEFAULT and /chopper on will disable hopper use on them
     denyHoppers: true
 
-    # Settable to private, public, donation, or off. It defines what protections are registered as when you place them
+    # Settable to private, public, donation, supply, or off. It defines what protections are registered as when you place them
     # on the ground
     autoRegister: off
 

--- a/src/main/resources/lang/lwc_en.properties
+++ b/src/main/resources/lang/lwc_en.properties
@@ -332,6 +332,7 @@ help.basic=\
 %white%/cprivate %dark_aqua%Create a private protection \n\
 %white%/cpublic %dark_aqua%Create a public protection \n\
 %white%/cdonation %dark_aqua%Create a donation chest \n\
+%white%/csupply %dark_aqua%Create a supply chest \n\
 %white%/cpassword %aqua%<Password> %dark_aqua%Create a password-protected protection \n\
 %white%/cmodify %dark_aqua%Modify an existing private protection \n\
 %white%/cunlock %aqua%<Password> %dark_aqua%Unlock a password-protected block \n\
@@ -611,6 +612,7 @@ protection.modes.nolock.off=%dark_green%Registration of new protections is now e
 
 display=Display
 prefix=%reset%
+supply=Supply
 
 lwc.admin.denied=%dark_red%You are not an LWC admin!
 

--- a/src/main/resources/lang/lwc_ja.properties
+++ b/src/main/resources/lang/lwc_ja.properties
@@ -330,6 +330,7 @@ help.basic=\
 %white%/cprivate %dark_aqua%個人保護を作成します \n\
 %white%/cpublic %dark_aqua%共有保護を作成します \n\
 %white%/cdonation %dark_aqua%寄付保護を作成します \n\
+%white%/csupply %dark_aqua%提供保護を作成します \n\
 %white%/cpassword %aqua%<Password> %dark_aqua%パスワード保護を作成します \n\
 %white%/cmodify %dark_aqua%既に存在する個人保護を編集します \n\
 %white%/cunlock %aqua%<Password> %dark_aqua%パスワード保護を解除します \n\
@@ -597,6 +598,7 @@ protection.modes.nolock.off=%dark_green%Registration of new protections is now e
 
 display=ディスプレイ
 prefix=%reset%
+supply=提供
 
 lwc.admin.denied=%dark_red%LWCの管理者のみこの操作が可能です
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -40,6 +40,9 @@ commands:
   cdisplay:
     description: Creates a chest that can be looked into, but only removed by player with access.
     usage: /<command>
+  csupply:
+    description: Creates a chest that can be take from, but only removed by player with access.
+    usage: /<command>
   cmodify:
     description: Modify an existing private protection.
     usage: /<command> <Modifications>
@@ -136,6 +139,7 @@ permissions:
           lwc.create.private: true
           lwc.create.donation: true
           lwc.create.display: true
+          lwc.create.supply: true
   lwc.create.public:
       description: Allows you to create a public protection.
   lwc.create.password:
@@ -146,6 +150,8 @@ permissions:
     description: Allows you to create a donation protection.
   lwc.create.display:
     description: Allows you to create a display protection.
+  lwc.create.supply:
+    description: Allows you to create a supply protection.
 
   lwc.modify:
       description: Allows you to modify protections you own, and use the default command.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -41,7 +41,7 @@ commands:
     description: Creates a chest that can be looked into, but only removed by player with access.
     usage: /<command>
   csupply:
-    description: Creates a chest that can be take from, but only removed by player with access.
+    description: Creates a chest that can be taken from, but only removed by player with access.
     usage: /<command>
   cmodify:
     description: Modify an existing private protection.


### PR DESCRIPTION
LWCX has now 5 protection type `public`, `private`, `password`, `donation` and `display`.
This PR adds new protection type `supply`.

`supply` protection type allows other players to take anything out but not put things into this protection. `supply` and `donation` are opposite. This can be good for chests that distribute items from monster farms, item sorter, or something.
