### PR TITLE
Compile against 1.20 and fix SnakeYAML 2.0 issues (Fixes #213)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.19.4-R0.1-SNAPSHOT")
+    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.20-R0.1-SNAPSHOT")
     compileOnly(group = "com.sk89q.worldedit", name = "worldedit-core", version = "7.1.0")
     compileOnly(group = "com.sk89q.worldguard", name = "worldguard-bukkit", version = "7.0.0")
     compileOnly(group = "com.palmergames.bukkit.towny", name = "towny", version = "0.98.2.0")

--- a/src/main/java/com/griefcraft/util/config/Configuration.java
+++ b/src/main/java/com/griefcraft/util/config/Configuration.java
@@ -30,6 +30,7 @@ package com.griefcraft.util.config;
 
 import com.griefcraft.scripting.ModuleLoader;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.reader.UnicodeReader;
@@ -66,7 +67,7 @@ public class Configuration extends ConfigurationNode {
         options.setIndent(4);
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
 
-        yaml = new Yaml(new SafeConstructor(), new Representer(), options);
+        yaml = new Yaml(new SafeConstructor(new LoaderOptions()), new Representer(options), options);
         this.file = file;
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: LWC
 main: com.griefcraft.lwc.LWCPlugin
 version: ${version}
-api-version: 1.20
+api-version: '1.20'
 author: Hidendra
 authors: [pop4959, Me_Goes_RAWR]
 website: https://www.spigotmc.org/resources/lwc-extended.69551/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: LWC
 main: com.griefcraft.lwc.LWCPlugin
 version: ${version}
-api-version: '1.20'
+api-version: '1.18'
 author: Hidendra
 authors: [pop4959, Me_Goes_RAWR]
 website: https://www.spigotmc.org/resources/lwc-extended.69551/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: LWC
 main: com.griefcraft.lwc.LWCPlugin
 version: ${version}
-api-version: 1.13
+api-version: 1.20
 author: Hidendra
 authors: [pop4959, Me_Goes_RAWR]
 website: https://www.spigotmc.org/resources/lwc-extended.69551/


### PR DESCRIPTION
This compiles against the new 1.20 spigot-api artifact and fixes issues with the SnakeYAMl 2.0.