### PR TITLE
Allow connections to newer MariaDB databases

### DIFF
--- a/src/main/java/com/griefcraft/io/BackupManager.java
+++ b/src/main/java/com/griefcraft/io/BackupManager.java
@@ -253,7 +253,7 @@ public class BackupManager {
                         // TODO separate stream logic to somewhere else :)
                         Statement resultStatement = database.getConnection().createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 
-                        if (lwc.getPhysicalDatabase().getType() == Database.Type.MySQL) {
+                        if (lwc.getPhysicalDatabase().getType().isMysqlBased()) {
                             resultStatement.setFetchSize(Integer.MIN_VALUE);
                         }
 

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1112,7 +1112,7 @@ public class LWC {
             Statement resultStatement = physicalDatabase.getConnection().createStatement(ResultSet.TYPE_FORWARD_ONLY,
                     ResultSet.CONCUR_READ_ONLY);
 
-            if (physicalDatabase.getType() == Database.Type.MySQL) {
+            if (physicalDatabase.getType().isMysqlBased()) {
                 resultStatement.setFetchSize(Integer.MIN_VALUE);
             }
 

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -420,6 +420,8 @@ public class LWCPlugin extends JavaPlugin {
 
         if (database.equalsIgnoreCase("mysql")) {
             Database.DefaultType = Database.Type.MySQL;
+        } else if (database.equalsIgnoreCase("mariadb")) {
+            Database.DefaultType = Database.Type.MariaDB;
         } else {
             Database.DefaultType = Database.Type.SQLite;
         }

--- a/src/main/java/com/griefcraft/migration/MySQLPost200.java
+++ b/src/main/java/com/griefcraft/migration/MySQLPost200.java
@@ -49,7 +49,7 @@ public class MySQLPost200 implements MigrationUtility {
 
         // this patcher only does something exciting if you have mysql enabled
         // :-)
-        if (physicalDatabase.getType() != Type.MySQL) {
+        if (!physicalDatabase.getType().isMysqlBased()) {
             return;
         }
 

--- a/src/main/java/com/griefcraft/modules/admin/AdminCleanup.java
+++ b/src/main/java/com/griefcraft/modules/admin/AdminCleanup.java
@@ -183,7 +183,7 @@ public class AdminCleanup extends JavaModule {
                 Statement resultStatement = database.getConnection().createStatement(ResultSet.TYPE_FORWARD_ONLY,
                         ResultSet.CONCUR_READ_ONLY);
 
-                if (lwc.getPhysicalDatabase().getType() == Database.Type.MySQL) {
+                if (lwc.getPhysicalDatabase().getType().isMysqlBased()) {
                     resultStatement.setFetchSize(Integer.MIN_VALUE);
                 }
 

--- a/src/main/java/com/griefcraft/sql/Database.java
+++ b/src/main/java/com/griefcraft/sql/Database.java
@@ -46,9 +46,20 @@ import java.util.concurrent.TimeUnit;
 public abstract class Database {
 
     public enum Type {
-        MySQL,
-        SQLite,
-        NONE;
+        MySQL(true),
+        SQLite(false),
+        MariaDB(true),
+        NONE(false);
+
+        private final boolean mysqlBased;
+
+        Type(boolean mysqlBased) {
+            this.mysqlBased = mysqlBased;
+        }
+
+        public boolean isMysqlBased() {
+            return mysqlBased;
+        }
 
         /**
          * Match the given string to a database type
@@ -204,7 +215,7 @@ public abstract class Database {
         Properties properties = new Properties();
 
         // if we're using MySQL, append the database info
-        if (currentType == Type.MySQL) {
+        if (currentType.isMysqlBased()) {
             LWC lwc = LWC.getInstance();
             properties.put("autoReconnect", "true");
             properties.put("user", lwc.getConfiguration().getString("database.username"));
@@ -272,7 +283,7 @@ public abstract class Database {
     public String getDatabasePath() {
         Configuration lwcConfiguration = LWC.getInstance().getConfiguration();
 
-        if (currentType == Type.MySQL) {
+        if (currentType.isMysqlBased()) {
             return "//" + lwcConfiguration.getString("database.host") + "/"
                     + lwcConfiguration.getString("database.database");
         }

--- a/src/main/java/com/griefcraft/sql/Table.java
+++ b/src/main/java/com/griefcraft/sql/Table.java
@@ -107,7 +107,7 @@ public class Table {
                 buffer.append("PRIMARY KEY ");
             }
 
-            if (column.shouldAutoIncrement() && database.getType() == Type.MySQL) {
+            if (column.shouldAutoIncrement() && database.getType().isMysqlBased()) {
                 buffer.append("AUTO_INCREMENT ");
             }
 
@@ -128,7 +128,7 @@ public class Table {
         buffer.append(" ) ");
 
         // if we're using mysql, check if we're in memory
-        if (memory && database.getType() == Type.MySQL) {
+        if (memory && database.getType().isMysqlBased()) {
             buffer.append("ENGINE = MEMORY");
         }
 


### PR DESCRIPTION
With MariaDB it's not possible anymore to connect to the database with the mysql database connector.

I already have the mariadb connector added to my server so I don't need it in LWC. It can be added and shaded if needed.

This PR allows to specify the new connection type "mariadb", since mariadb and mysql has the same capabilities there is no other change needed.