### PR TITLE
Don't use InventoryHolder snapshots on paper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
-import java.util.*
+import java.util.Locale
+
 
 plugins {
     id("java-library")
@@ -24,16 +25,15 @@ repositories {
 }
 
 dependencies {
-    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.20.6-R0.1-SNAPSHOT")
-    compileOnly(group = "com.sk89q.worldedit", name = "worldedit-core", version = "7.1.0")
-    compileOnly(group = "com.sk89q.worldguard", name = "worldguard-bukkit", version = "7.0.0")
-    compileOnly(group = "com.palmergames.bukkit.towny", name = "towny", version = "0.98.2.0")
-    compileOnly(group = "com.massivecraft", name = "Factions", version = "1.6.9.5-U0.4.9") {
-        isTransitive = false
-    }
-    compileOnly(group = "com.github.MilkBowl", name = "VaultAPI", version = "1.7.1")
-    compileOnly(group = "com.google.guava", name = "guava", version = "23.0")
-    implementation(group = "org.bstats", name = "bstats-bukkit", version = "3.0.2")
+    compileOnly("org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT")
+    compileOnly("com.sk89q.worldedit:worldedit-core:7.1.0")
+    compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.0")
+    compileOnly("com.palmergames.bukkit.towny:towny:0.98.2.0")
+    compileOnly("com.massivecraft:Factions:1.6.9.5-U0.4.9") { isTransitive = false }
+    compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
+    compileOnly("com.google.guava:guava:23.0")
+    implementation("com.github.PaperMC:PaperLib:v1.0.8")
+    implementation("org.bstats:bstats-bukkit:3.0.2")
 }
 
 tasks {
@@ -54,6 +54,7 @@ tasks {
         archiveClassifier.set("")
         archiveFileName.set("${rootProject.name.uppercase(Locale.getDefault())}-${project.version}.jar")
         relocate("org.bstats", "${project.group}.${rootProject.name}.lib.bstats")
+        relocate("io.papermc.lib", "${project.group}.${rootProject.name}.lib.paperlib")
         manifest {
             attributes("paperweight-mappings-namespace" to "mojang")
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx2G
 group=com.griefcraft
-version=2.4.0
+version=2.4.1
 description=Inventory protection & management utilizing SQLite or MySQL as its backend.
 github=https://github.com/pop4959/LWCX

--- a/src/main/java/com/griefcraft/bukkit/HopperMinecartBlock.java
+++ b/src/main/java/com/griefcraft/bukkit/HopperMinecartBlock.java
@@ -1,5 +1,6 @@
 package com.griefcraft.bukkit;
 
+import com.griefcraft.util.InvHolderUtil;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.minecart.HopperMinecart;
 
@@ -12,7 +13,7 @@ public class HopperMinecartBlock extends EntityBlock {
     }
 
     public BlockState getState() {
-        return (BlockState) this.minecart.getInventory().getHolder();
+        return (BlockState) InvHolderUtil.get(this.minecart.getInventory());
     }
 
     public HopperMinecart getMinecart() {

--- a/src/main/java/com/griefcraft/bukkit/StoreageMinecartBlock.java
+++ b/src/main/java/com/griefcraft/bukkit/StoreageMinecartBlock.java
@@ -1,5 +1,6 @@
 package com.griefcraft.bukkit;
 
+import com.griefcraft.util.InvHolderUtil;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.minecart.StorageMinecart;
 
@@ -12,7 +13,7 @@ public class StoreageMinecartBlock extends EntityBlock {
     }
 
     public BlockState getState() {
-        return (BlockState) this.minecart.getInventory().getHolder();
+        return (BlockState) InvHolderUtil.get(this.minecart.getInventory());
     }
 
     public StorageMinecart getMinecart() {

--- a/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -39,6 +39,7 @@ import com.griefcraft.model.Permission;
 import com.griefcraft.model.Protection;
 import com.griefcraft.scripting.Module;
 import com.griefcraft.scripting.event.*;
+import com.griefcraft.util.InvHolderUtil;
 import com.griefcraft.util.UUIDRegistry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -316,7 +317,7 @@ public class LWCPlayerListener implements Listener {
 
     @EventHandler
     public void storageMinecraftInventoryOpen(InventoryOpenEvent event) {
-        InventoryHolder holder = event.getInventory().getHolder();
+        InventoryHolder holder = InvHolderUtil.get(event.getInventory());
         Player player = (Player) event.getPlayer();
         if ((!(holder instanceof StorageMinecart)) && (!(holder instanceof HopperMinecart))) {
             return;
@@ -446,8 +447,12 @@ public class LWCPlayerListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onMoveItem(InventoryMoveItemEvent event) {
-        if (plugin.getLWC().useAlternativeHopperProtection()
-                && !(event.getSource().getHolder() instanceof HopperMinecart || event.getDestination().getHolder() instanceof HopperMinecart)) {
+        // The InventoryHolder checks below will still get called if not put in another if statement check.
+        // Moved into else-if to prevent wasted resources when the configuration is set to use the alternative hopper protection.
+        if (plugin.getLWC().useAlternativeHopperProtection()) {
+            return;
+        } else if (!(InvHolderUtil.get(event.getSource()) instanceof HopperMinecart ||
+                InvHolderUtil.get(event.getDestination()) instanceof HopperMinecart)) {
             return;
         }
 
@@ -484,8 +489,8 @@ public class LWCPlayerListener implements Listener {
         InventoryHolder initiatorHolder;
 
         try {
-            holder = inventory.getHolder();
-            initiatorHolder = initiator.getHolder();
+            holder = InvHolderUtil.get(inventory);
+            initiatorHolder = InvHolderUtil.get(initiator);
         } catch (AbstractMethodError e) {
             return false;
         }
@@ -756,7 +761,7 @@ public class LWCPlayerListener implements Listener {
         InventoryHolder holder = null;
 
         try {
-            holder = event.getInventory().getHolder();
+            holder = InvHolderUtil.get(event.getInventory());
         } catch (AbstractMethodError e) {
             e.printStackTrace();
             return;
@@ -927,7 +932,7 @@ public class LWCPlayerListener implements Listener {
         InventoryHolder holder = null;
 
         try {
-            holder = event.getInventory().getHolder();
+            holder = InvHolderUtil.get(event.getInventory());
         } catch (AbstractMethodError e) {
             e.printStackTrace();
             return;

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -38,16 +38,19 @@ import com.griefcraft.modules.pluginsupport.Towny;
 import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.sql.Database;
 import com.griefcraft.util.Completions;
+import com.griefcraft.util.InvHolderUtil;
 import com.griefcraft.util.StringUtil;
 import com.griefcraft.util.Updater;
 import com.griefcraft.util.VersionUtil;
 import com.griefcraft.util.locale.LWCResourceBundle;
 import com.griefcraft.util.locale.LocaleClassLoader;
 import com.griefcraft.util.locale.UTF8Control;
+import io.papermc.lib.PaperLib;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
 import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -103,83 +106,108 @@ public class LWCPlugin extends JavaPlugin {
             String aliasCommand = null;
             String[] aliasArgs = new String[0];
 
-            if (commandName.equals("cpublic")) {
-                aliasCommand = "create";
-                aliasArgs = new String[]{"public"};
-            } else if (commandName.equals("cpassword")) {
-                aliasCommand = "create";
-                aliasArgs = ("password " + argString).split(" ");
-            } else if (commandName.equals("cprivate") || commandName.equals("lock")) {
-                aliasCommand = "create";
-                aliasArgs = ("private " + argString).split(" ");
-            } else if (commandName.equals("cdonation")) {
-                aliasCommand = "create";
-                aliasArgs = ("donation " + argString).split(" ");
-            } else if (commandName.equals("cdisplay")) {
-                aliasCommand = "create";
-                aliasArgs = ("display " + argString).split(" ");
-            } else if (commandName.equals("csupply")) {
-                aliasCommand = "create";
-                aliasArgs = ("supply " + argString).split(" ");
-            } else if (commandName.equals("cmodify")) {
-                aliasCommand = "modify";
-                aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
-            } else if (commandName.equals("cinfo")) {
-                aliasCommand = "info";
-            } else if (commandName.equals("cunlock")) {
-                aliasCommand = "unlock";
-                aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
-            } else if (commandName.equals("cremove") || commandName.equals("unlock")) {
-                aliasCommand = "remove";
-                aliasArgs = new String[]{"protection"};
-            } else if (commandName.equals("climits")) {
-                aliasCommand = "limits";
-                aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
-            } else if (commandName.equals("cadmin")) {
-                aliasCommand = "admin";
-                aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
-            } else if (commandName.equals("cremoveall")) {
-                aliasCommand = "remove";
-                aliasArgs = new String[]{"allprotections"};
-            } else if (commandName.equals("cdefault")) {
-                aliasCommand = "default";
-                aliasArgs = new String[]{argString};
+            switch (commandName) {
+                case "cpublic" -> {
+                    aliasCommand = "create";
+                    aliasArgs = new String[]{"public"};
+                }
+                case "cpassword" -> {
+                    aliasCommand = "create";
+                    aliasArgs = ("password " + argString).split(" ");
+                }
+                case "cprivate", "lock" -> {
+                    aliasCommand = "create";
+                    aliasArgs = ("private " + argString).split(" ");
+                }
+                case "cdonation" -> {
+                    aliasCommand = "create";
+                    aliasArgs = ("donation " + argString).split(" ");
+                }
+                case "cdisplay" -> {
+                    aliasCommand = "create";
+                    aliasArgs = ("display " + argString).split(" ");
+                }
+                case "csupply" -> {
+                    aliasCommand = "create";
+                    aliasArgs = ("supply " + argString).split(" ");
+                }
+                case "cmodify" -> {
+                    aliasCommand = "modify";
+                    aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
+                }
+                case "cinfo" -> aliasCommand = "info";
+                case "cunlock" -> {
+                    aliasCommand = "unlock";
+                    aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
+                }
+                case "cremove", "unlock" -> {
+                    aliasCommand = "remove";
+                    aliasArgs = new String[]{"protection"};
+                }
+                case "climits" -> {
+                    aliasCommand = "limits";
+                    aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
+                }
+                case "cadmin" -> {
+                    aliasCommand = "admin";
+                    aliasArgs = argString.isEmpty() ? new String[0] : argString.split(" ");
+                }
+                case "cremoveall" -> {
+                    aliasCommand = "remove";
+                    aliasArgs = new String[]{"allprotections"};
+                }
+                case "cdefault" -> {
+                    aliasCommand = "default";
+                    aliasArgs = new String[]{argString};
+                }
             }
 
             // Flag aliases
-            if (commandName.equals("credstone")) {
-                aliasCommand = "flag";
-                aliasArgs = ("redstone " + argString).split(" ");
-            } else if (commandName.equals("cmagnet")) {
-                aliasCommand = "flag";
-                aliasArgs = ("magnet " + argString).split(" ");
-            } else if (commandName.equals("cexempt")) {
-                aliasCommand = "flag";
-                aliasArgs = ("exemption " + argString).split(" ");
-            } else if (commandName.equals("cautoclose")) {
-                aliasCommand = "flag";
-                aliasArgs = ("autoclose " + argString).split(" ");
-            } else if (commandName.equals("callowexplosions") || commandName.equals("ctnt")) {
-                aliasCommand = "flag";
-                aliasArgs = ("allowexplosions " + argString).split(" ");
-            } else if (commandName.equals("chopper")) {
-                aliasCommand = "flag";
-                aliasArgs = ("hopper " + argString).split(" ");
+            switch (commandName) {
+                case "credstone" -> {
+                    aliasCommand = "flag";
+                    aliasArgs = ("redstone " + argString).split(" ");
+                }
+                case "cmagnet" -> {
+                    aliasCommand = "flag";
+                    aliasArgs = ("magnet " + argString).split(" ");
+                }
+                case "cexempt" -> {
+                    aliasCommand = "flag";
+                    aliasArgs = ("exemption " + argString).split(" ");
+                }
+                case "cautoclose" -> {
+                    aliasCommand = "flag";
+                    aliasArgs = ("autoclose " + argString).split(" ");
+                }
+                case "callowexplosions", "ctnt" -> {
+                    aliasCommand = "flag";
+                    aliasArgs = ("allowexplosions " + argString).split(" ");
+                }
+                case "chopper" -> {
+                    aliasCommand = "flag";
+                    aliasArgs = ("hopper " + argString).split(" ");
+                }
             }
 
             // Mode aliases
-            if (commandName.equals("cdroptransfer")) {
-                aliasCommand = "mode";
-                aliasArgs = ("droptransfer " + argString).split(" ");
-            } else if (commandName.equals("cpersist")) {
-                aliasCommand = "mode";
-                aliasArgs = ("persist " + argString).split(" ");
-            } else if (commandName.equals("cnospam")) {
-                aliasCommand = "mode";
-                aliasArgs = ("nospam " + argString).split(" ");
-            } else if (commandName.equals("cnolock")) {
-                aliasCommand = "mode";
-                aliasArgs = ("nolock " + argString).split(" ");
+            switch (commandName) {
+                case "cdroptransfer" -> {
+                    aliasCommand = "mode";
+                    aliasArgs = ("droptransfer " + argString).split(" ");
+                }
+                case "cpersist" -> {
+                    aliasCommand = "mode";
+                    aliasArgs = ("persist " + argString).split(" ");
+                }
+                case "cnospam" -> {
+                    aliasCommand = "mode";
+                    aliasArgs = ("nospam " + argString).split(" ");
+                }
+                case "cnolock" -> {
+                    aliasCommand = "mode";
+                    aliasArgs = ("nolock " + argString).split(" ");
+                }
             }
 
             if (aliasCommand != null) {
@@ -372,7 +400,7 @@ public class LWCPlugin extends JavaPlugin {
         Metrics m = new Metrics(this, 5180);
 
         m.addCustomChart(new AdvancedPie("protected_blocks", () -> {
-            Map<String, Integer> map = new HashMap<String, Integer>();
+            Map<String, Integer> map = new HashMap<>();
 
             if (lwc.getPhysicalDatabase().getProtectionCount() >= 50000) {
                 map.put("Over 50k", 1);
@@ -410,6 +438,14 @@ public class LWCPlugin extends JavaPlugin {
         // Load the rest of LWC
         lwc.load();
         registerEvents();
+    
+
+        if (PaperLib.isPaper()) {
+            InvHolderUtil.setOptionalSnapshots(true);
+        } else {
+            getServer().getConsoleSender().sendMessage(ChatColor.GREEN + "[LWC] LWCX will perform better when running Paper (or forks of Paper)!");
+            getServer().getConsoleSender().sendMessage(ChatColor.GREEN + "[LWC] Consider checking out the PaperMC server software: " + ChatColor.GOLD + "https://papermc.io");
+        }
     }
 
     /**

--- a/src/main/java/com/griefcraft/util/InvHolderUtil.java
+++ b/src/main/java/com/griefcraft/util/InvHolderUtil.java
@@ -1,0 +1,24 @@
+package com.griefcraft.util;
+
+import io.papermc.lib.features.inventoryholdersnapshot.InventoryHolderSnapshotOptionalSnapshots;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public final class InvHolderUtil {
+
+    private static final InventoryHolderSnapshotOptionalSnapshots inventoryHolderSnapshotOptionalSnapshots = new InventoryHolderSnapshotOptionalSnapshots();
+    private static boolean optionalSnapshots = false;
+
+
+    public static void setOptionalSnapshots(boolean b) {
+        optionalSnapshots = b;
+    }
+
+    public static InventoryHolder get(Inventory inventory) {
+        if (optionalSnapshots) {
+            return inventoryHolderSnapshotOptionalSnapshots.getHolder(inventory, false).getHolder();
+        } else {
+            return inventory.getHolder();
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ website: https://www.spigotmc.org/resources/lwc-extended.69551/
 description: >
              Inventory protection & management utilizing SQLite or MySQL as its backend
              Other blocks can also be protected individually, if configured.
-load: startup
+load: STARTUP
 softdepend: [Vault, WorldEdit, WorldGuard, Towny, Factions]
 
 commands:


### PR DESCRIPTION
Commit message was supposed to be the title of this pr.

Adds checks to see if LWC is running on paper and won't use InventoryHolder snapshots if it's using paper. Also suggests using paper if paper is not being used on startup.