### PR TITLE
Added copper chest variants (fixes #250)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.1-R0.1-SNAPSHOT")
+    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.11-R0.1-SNAPSHOT")
     compileOnly(group = "com.sk89q.worldedit", name = "worldedit-core", version = "7.1.0")
     compileOnly(group = "com.sk89q.worldguard", name = "worldguard-bukkit", version = "7.0.0")
     compileOnly(group = "com.palmergames.bukkit.towny", name = "towny", version = "0.98.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.11-R0.1-SNAPSHOT")
+    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.1-R0.1-SNAPSHOT")
     compileOnly(group = "com.sk89q.worldedit", name = "worldedit-core", version = "7.1.0")
     compileOnly(group = "com.sk89q.worldguard", name = "worldguard-bukkit", version = "7.0.0")
     compileOnly(group = "com.palmergames.bukkit.towny", name = "towny", version = "0.98.2.0")

--- a/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
@@ -46,8 +46,20 @@ public class DoubleChestMatcher implements ProtectionFinder.Matcher {
     /**
      * Blocks that act like double chests
      */
-    public static final Set<Material> PROTECTABLES_CHESTS = EnumSet.of(Material.CHEST, Material.TRAPPED_CHEST);
+    public static final Set<Material> PROTECTABLES_CHESTS = EnumSet.of(
+            Material.CHEST,
+            Material.TRAPPED_CHEST,
+            Material.COPPER_CHEST,
 
+            // Copper chest variants
+            Material.EXPOSED_COPPER_CHEST,
+            Material.WEATHERED_COPPER_CHEST,
+            Material.OXIDIZED_COPPER_CHEST,
+            Material.WAXED_COPPER_GRATE,
+            Material.WAXED_EXPOSED_COPPER_CHEST,
+            Material.WAXED_WEATHERED_COPPER_CHEST,
+            Material.WAXED_OXIDIZED_COPPER_CHEST
+    );
     /**
      * Possible faces around the base block that protections could be at
      */

--- a/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
@@ -29,6 +29,7 @@
 package com.griefcraft.util.matchers;
 
 import com.griefcraft.util.ProtectionFinder;
+import com.griefcraft.util.VersionUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -36,6 +37,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Chest;
 
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -48,18 +50,22 @@ public class DoubleChestMatcher implements ProtectionFinder.Matcher {
      */
     public static final Set<Material> PROTECTABLES_CHESTS = EnumSet.of(
             Material.CHEST,
-            Material.TRAPPED_CHEST,
-            Material.COPPER_CHEST,
-
-            // Copper chest variants
-            Material.EXPOSED_COPPER_CHEST,
-            Material.WEATHERED_COPPER_CHEST,
-            Material.OXIDIZED_COPPER_CHEST,
-            Material.WAXED_COPPER_GRATE,
-            Material.WAXED_EXPOSED_COPPER_CHEST,
-            Material.WAXED_WEATHERED_COPPER_CHEST,
-            Material.WAXED_OXIDIZED_COPPER_CHEST
+            Material.TRAPPED_CHEST
     );
+
+    static {
+        if (VersionUtil.getMinorVersion() > 20) {
+            Optional.ofNullable(Material.getMaterial("COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("EXPOSED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WEATHERED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("OXIDIZED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_EXPOSED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_WEATHERED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_OXIDIZED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+        }
+    }
+
     /**
      * Possible faces around the base block that protections could be at
      */


### PR DESCRIPTION
This updates the Spigot API to version 1.21.11 and fixes the issue with double copper chests not being registered.