### PR TITLE
Make case-sensitivity of lock passwords configurable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.1-R0.1-SNAPSHOT")
+    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.11-R0.1-SNAPSHOT")
     compileOnly(group = "com.sk89q.worldedit", name = "worldedit-core", version = "7.1.0")
     compileOnly(group = "com.sk89q.worldguard", name = "worldguard-bukkit", version = "7.0.0")
     compileOnly(group = "com.palmergames.bukkit.towny", name = "towny", version = "0.98.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.11-R0.1-SNAPSHOT")
+    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.21.1-R0.1-SNAPSHOT")
     compileOnly(group = "com.sk89q.worldedit", name = "worldedit-core", version = "7.1.0")
     compileOnly(group = "com.sk89q.worldguard", name = "worldguard-bukkit", version = "7.0.0")
     compileOnly(group = "com.palmergames.bukkit.towny", name = "towny", version = "0.98.2.0")

--- a/src/main/java/com/griefcraft/modules/create/CreateModule.java
+++ b/src/main/java/com/griefcraft/modules/create/CreateModule.java
@@ -152,7 +152,7 @@ public class CreateModule extends JavaModule {
             }
             lwc.sendLocale(player, "protection.interact.create.finalize");
         } else if (protectionType.equals("password")) {
-            String password = lwc.encrypt(protectionData);
+            String password = lwc.encrypt(protectionData.toLowerCase()); // added to remove case sensitivity
 
             if (block instanceof EntityBlock) {
                 protection = physDb.registerProtection(EntityBlock.ENTITY_BLOCK_ID, Protection.Type.PASSWORD,
@@ -179,7 +179,7 @@ public class CreateModule extends JavaModule {
             }
 
             lwc.sendLocale(player, "protection.interact.create.finalize");
-            lwc.processRightsModifications(player, protection, rights);
+           lwc.processRightsModifications(player, protection, rights);
         }
 
         // tell the modules that a protection was registered

--- a/src/main/java/com/griefcraft/modules/create/CreateModule.java
+++ b/src/main/java/com/griefcraft/modules/create/CreateModule.java
@@ -152,7 +152,8 @@ public class CreateModule extends JavaModule {
             }
             lwc.sendLocale(player, "protection.interact.create.finalize");
         } else if (protectionType.equals("password")) {
-            String password = lwc.encrypt(protectionData.toLowerCase()); // added to remove case sensitivity
+            boolean isCaseEnabled = LWC.getInstance().getConfiguration().getBoolean("optional.useCaseSensitivePasswordsInLocks", true);
+            String password = isCaseEnabled ? lwc.encrypt(protectionData) : lwc.encrypt(protectionData.toLowerCase());
 
             if (block instanceof EntityBlock) {
                 protection = physDb.registerProtection(EntityBlock.ENTITY_BLOCK_ID, Protection.Type.PASSWORD,

--- a/src/main/java/com/griefcraft/modules/create/CreateModule.java
+++ b/src/main/java/com/griefcraft/modules/create/CreateModule.java
@@ -180,7 +180,7 @@ public class CreateModule extends JavaModule {
             }
 
             lwc.sendLocale(player, "protection.interact.create.finalize");
-           lwc.processRightsModifications(player, protection, rights);
+            lwc.processRightsModifications(player, protection, rights);
         }
 
         // tell the modules that a protection was registered

--- a/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
+++ b/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
@@ -74,7 +74,7 @@ public class UnlockModule extends JavaModule {
 
         LWCPlayer player = lwc.wrapPlayer(sender);
         String password = join(args, 0);
-        password = encrypt(password);
+        password = encrypt(password.toLowerCase()); // added to remove case sensitivity
 
         // see if they have the protection interaction action
         Action action = player.getAction("interacted");

--- a/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
+++ b/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
@@ -73,9 +73,10 @@ public class UnlockModule extends JavaModule {
         }
 
         LWCPlayer player = lwc.wrapPlayer(sender);
+        boolean isCaseEnabled = LWC.getInstance().getConfiguration().getBoolean("optional.useCaseSensitivePasswordsInLocks", true);
         String password = join(args, 0);
-        String casedPassword = encrypt(password); // save to match cased password for old locks
-        password = encrypt(password.toLowerCase()); // added to remove case sensitivity
+        String lowercasePassword = encrypt(password.toLowerCase()); // for when case disabled
+        password = encrypt(password); // cased password
 
         // see if they have the protection interaction action
         Action action = player.getAction("interacted");
@@ -95,8 +96,7 @@ public class UnlockModule extends JavaModule {
                 return;
             }
 
-            // add check for old cased passwords
-            if (protection.getPassword().equals(password) || protection.getPassword().equals(casedPassword)) {
+            if (protection.getPassword().equals(password) || !isCaseEnabled && protection.getPassword().equals(lowercasePassword)) {
                 player.addAccessibleProtection(protection);
                 player.removeAction(action);
                 lwc.sendLocale(player, "protection.unlock.password.valid");

--- a/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
+++ b/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
@@ -74,6 +74,7 @@ public class UnlockModule extends JavaModule {
 
         LWCPlayer player = lwc.wrapPlayer(sender);
         String password = join(args, 0);
+        String casedPassword = encrypt(password); // save to match cased password for old locks
         password = encrypt(password.toLowerCase()); // added to remove case sensitivity
 
         // see if they have the protection interaction action
@@ -94,7 +95,8 @@ public class UnlockModule extends JavaModule {
                 return;
             }
 
-            if (protection.getPassword().equals(password)) {
+            // add check for old cased passwords
+            if (protection.getPassword().equals(password) || protection.getPassword().equals(casedPassword)) {
                 player.addAccessibleProtection(protection);
                 player.removeAction(action);
                 lwc.sendLocale(player, "protection.unlock.password.valid");

--- a/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
@@ -46,8 +46,20 @@ public class DoubleChestMatcher implements ProtectionFinder.Matcher {
     /**
      * Blocks that act like double chests
      */
-    public static final Set<Material> PROTECTABLES_CHESTS = EnumSet.of(Material.CHEST, Material.TRAPPED_CHEST);
+    public static final Set<Material> PROTECTABLES_CHESTS = EnumSet.of(
+            Material.CHEST,
+            Material.TRAPPED_CHEST,
+            Material.COPPER_CHEST,
 
+            // Copper chest variants
+            Material.EXPOSED_COPPER_CHEST,
+            Material.WEATHERED_COPPER_CHEST,
+            Material.OXIDIZED_COPPER_CHEST,
+            Material.WAXED_COPPER_GRATE,
+            Material.WAXED_EXPOSED_COPPER_CHEST,
+            Material.WAXED_WEATHERED_COPPER_CHEST,
+            Material.WAXED_OXIDIZED_COPPER_CHEST
+    );
     /**
      * Possible faces around the base block that protections could be at
      */

--- a/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/DoubleChestMatcher.java
@@ -29,6 +29,7 @@
 package com.griefcraft.util.matchers;
 
 import com.griefcraft.util.ProtectionFinder;
+import com.griefcraft.util.VersionUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -36,6 +37,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Chest;
 
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -48,18 +50,22 @@ public class DoubleChestMatcher implements ProtectionFinder.Matcher {
      */
     public static final Set<Material> PROTECTABLES_CHESTS = EnumSet.of(
             Material.CHEST,
-            Material.TRAPPED_CHEST,
-            Material.COPPER_CHEST,
-
-            // Copper chest variants
-            Material.EXPOSED_COPPER_CHEST,
-            Material.WEATHERED_COPPER_CHEST,
-            Material.OXIDIZED_COPPER_CHEST,
-            Material.WAXED_COPPER_GRATE,
-            Material.WAXED_EXPOSED_COPPER_CHEST,
-            Material.WAXED_WEATHERED_COPPER_CHEST,
-            Material.WAXED_OXIDIZED_COPPER_CHEST
+            Material.TRAPPED_CHEST
     );
+
+    static {
+        if (VersionUtil.getMinorVersion() > 20) {
+            Optional.ofNullable(Material.getMaterial("COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("EXPOSED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WEATHERED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("OXIDIZED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_EXPOSED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_WEATHERED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+            Optional.ofNullable(Material.getMaterial("WAXED_OXIDIZED_COPPER_CHEST")).ifPresent(PROTECTABLES_CHESTS::add);
+        }
+    }
+
     /**
      * Possible faces around the base block that protections could be at
      */

--- a/src/main/resources/config/core.yml
+++ b/src/main/resources/config/core.yml
@@ -85,6 +85,9 @@ optional:
     # information will be displayed instead (default in versions prior to 2.2.3).
     useFormattedInfo: true
 
+  # Password locks are case sensitive
+    useCaseSensitivePasswordsInLocks: true
+
 # Database information for LWC
 database:
 

--- a/src/main/resources/config/core.yml
+++ b/src/main/resources/config/core.yml
@@ -190,6 +190,30 @@ protections:
         trapped_chest:
             enabled: true
             autoRegister: private
+        copper_chest:
+            enabled: true
+            autoRegister: private
+        waxed_copper_chest:
+            enabled: true
+            autoRegister: private
+        exposed_copper_chest:
+            enabled: true
+            autoRegister: private
+        waxed_exposed_copper_chest:
+            enabled: true
+            autoRegister: private
+        weathered_copper_chest:
+            enabled: true
+            autoRegister: private
+        waxed_weathered_copper_chest:
+            enabled: true
+            autoRegister: private
+        oxidized_copper_chest:
+            enabled: true
+            autoRegister: private
+        waxed_oxidized_copper_chest:
+            enabled: true
+            autoRegister: private
         furnace:
             enabled: true
             autoRegister: private


### PR DESCRIPTION
Adds a config option: `useCaseSensitivePasswordsInLocks`, defaulting to true. 
When set to false, changes behavior to make locks case insensitive.  
Useful for servers where password locks don't need the security but people have trouble with case-sensitivity and/or passworded locks are primarily used for trivia, etc, where case sensitivity causes issues.