### PR TITLE
Add config option to have chest passwords not case-sensitive

### DIFF
--- a/src/main/java/com/griefcraft/modules/create/CreateModule.java
+++ b/src/main/java/com/griefcraft/modules/create/CreateModule.java
@@ -152,7 +152,7 @@ public class CreateModule extends JavaModule {
             }
             lwc.sendLocale(player, "protection.interact.create.finalize");
         } else if (protectionType.equals("password")) {
-            String password = lwc.encrypt(protectionData);
+            String password = lwc.encrypt(protectionData.toLowerCase()); // added to remove case sensitivity
 
             if (block instanceof EntityBlock) {
                 protection = physDb.registerProtection(EntityBlock.ENTITY_BLOCK_ID, Protection.Type.PASSWORD,
@@ -179,7 +179,7 @@ public class CreateModule extends JavaModule {
             }
 
             lwc.sendLocale(player, "protection.interact.create.finalize");
-            lwc.processRightsModifications(player, protection, rights);
+           lwc.processRightsModifications(player, protection, rights);
         }
 
         // tell the modules that a protection was registered

--- a/src/main/java/com/griefcraft/modules/create/CreateModule.java
+++ b/src/main/java/com/griefcraft/modules/create/CreateModule.java
@@ -152,7 +152,8 @@ public class CreateModule extends JavaModule {
             }
             lwc.sendLocale(player, "protection.interact.create.finalize");
         } else if (protectionType.equals("password")) {
-            String password = lwc.encrypt(protectionData.toLowerCase()); // added to remove case sensitivity
+            boolean isCaseEnabled = LWC.getInstance().getConfiguration().getBoolean("optional.useCaseSensitivePasswordsInLocks", true);
+            String password = isCaseEnabled ? lwc.encrypt(protectionData) : lwc.encrypt(protectionData.toLowerCase());
 
             if (block instanceof EntityBlock) {
                 protection = physDb.registerProtection(EntityBlock.ENTITY_BLOCK_ID, Protection.Type.PASSWORD,

--- a/src/main/java/com/griefcraft/modules/create/CreateModule.java
+++ b/src/main/java/com/griefcraft/modules/create/CreateModule.java
@@ -180,7 +180,7 @@ public class CreateModule extends JavaModule {
             }
 
             lwc.sendLocale(player, "protection.interact.create.finalize");
-           lwc.processRightsModifications(player, protection, rights);
+            lwc.processRightsModifications(player, protection, rights);
         }
 
         // tell the modules that a protection was registered

--- a/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
+++ b/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
@@ -74,7 +74,7 @@ public class UnlockModule extends JavaModule {
 
         LWCPlayer player = lwc.wrapPlayer(sender);
         String password = join(args, 0);
-        password = encrypt(password);
+        password = encrypt(password.toLowerCase()); // added to remove case sensitivity
 
         // see if they have the protection interaction action
         Action action = player.getAction("interacted");

--- a/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
+++ b/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
@@ -73,9 +73,10 @@ public class UnlockModule extends JavaModule {
         }
 
         LWCPlayer player = lwc.wrapPlayer(sender);
+        boolean isCaseEnabled = LWC.getInstance().getConfiguration().getBoolean("optional.useCaseSensitivePasswordsInLocks", true);
         String password = join(args, 0);
-        String casedPassword = encrypt(password); // save to match cased password for old locks
-        password = encrypt(password.toLowerCase()); // added to remove case sensitivity
+        String lowercasePassword = encrypt(password.toLowerCase()); // for when case disabled
+        password = encrypt(password); // cased password
 
         // see if they have the protection interaction action
         Action action = player.getAction("interacted");
@@ -95,8 +96,7 @@ public class UnlockModule extends JavaModule {
                 return;
             }
 
-            // add check for old cased passwords
-            if (protection.getPassword().equals(password) || protection.getPassword().equals(casedPassword)) {
+            if (protection.getPassword().equals(password) || !isCaseEnabled && protection.getPassword().equals(lowercasePassword)) {
                 player.addAccessibleProtection(protection);
                 player.removeAction(action);
                 lwc.sendLocale(player, "protection.unlock.password.valid");

--- a/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
+++ b/src/main/java/com/griefcraft/modules/unlock/UnlockModule.java
@@ -74,6 +74,7 @@ public class UnlockModule extends JavaModule {
 
         LWCPlayer player = lwc.wrapPlayer(sender);
         String password = join(args, 0);
+        String casedPassword = encrypt(password); // save to match cased password for old locks
         password = encrypt(password.toLowerCase()); // added to remove case sensitivity
 
         // see if they have the protection interaction action
@@ -94,7 +95,8 @@ public class UnlockModule extends JavaModule {
                 return;
             }
 
-            if (protection.getPassword().equals(password)) {
+            // add check for old cased passwords
+            if (protection.getPassword().equals(password) || protection.getPassword().equals(casedPassword)) {
                 player.addAccessibleProtection(protection);
                 player.removeAction(action);
                 lwc.sendLocale(player, "protection.unlock.password.valid");

--- a/src/main/resources/config/core.yml
+++ b/src/main/resources/config/core.yml
@@ -85,6 +85,9 @@ optional:
     # information will be displayed instead (default in versions prior to 2.2.3).
     useFormattedInfo: true
 
+  # Password locks are case sensitive
+    useCaseSensitivePasswordsInLocks: true
+
 # Database information for LWC
 database:
 


### PR DESCRIPTION
Here's a clean branch with just the PR related commits.

The idea here was this was that servers who aren't using passwords as the main security feature can make it easier for players to do things like trivia games by choosing for locks not to have case sensitivity.  