### PR TITLE
Replacing failed to register events with a warning and info #265

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -522,7 +522,14 @@ public class LWCPlugin extends JavaPlugin {
             pluginManager.registerEvents(new LWC114Listener(), this);
         }
         if (VersionUtil.isAtLeast(1, 21, 11)) {
-            pluginManager.registerEvents(new LWC12111Listener(), this);
+            try {
+                Class.forName("EntityTargetBlockEvent");
+                pluginManager.registerEvents(new LWC12111Listener(), this);
+            } catch (ClassNotFoundException exception) {
+                getLogger().log(Level.WARNING, "You seem to be using the Spigot build on an outdated Spigot server " +
+                        "version, or on paper. Please switch your version to the correct one for your platform: Paper: " +
+                        "https://modrinth.com/plugin/lwc Spigot: https://www.spigotmc.org/resources/lwc-extended.69551/");
+            }
         }
         if (Bukkit.getPluginManager().getPlugin("Towny") != null) {
             pluginManager.registerEvents(new Towny(), this);

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -526,9 +526,8 @@ public class LWCPlugin extends JavaPlugin {
                 Class.forName("EntityTargetBlockEvent");
                 pluginManager.registerEvents(new LWC12111Listener(), this);
             } catch (ClassNotFoundException exception) {
-                getLogger().log(Level.WARNING, "You seem to be using the Spigot build on an outdated Spigot server " +
-                        "version, or on paper. Please switch your version to the correct one for your platform: Paper: " +
-                        "https://modrinth.com/plugin/lwc Spigot: https://www.spigotmc.org/resources/lwc-extended.69551/");
+                getLogger().log(Level.WARNING, "You seem to be running the Spigot build on Paper. Please consider" +
+                        " using the paper build instead: https://modrinth.com/plugin/lwc");
             }
         }
         if (Bukkit.getPluginManager().getPlugin("Towny") != null) {

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -527,7 +527,7 @@ public class LWCPlugin extends JavaPlugin {
                 pluginManager.registerEvents(new LWC12111Listener(), this);
             } catch (ClassNotFoundException exception) {
                 getLogger().log(Level.WARNING, "You seem to be running the Spigot build on Paper. Please consider" +
-                        " using the paper build instead: https://modrinth.com/plugin/lwc");
+                        " using the Paper build instead: https://modrinth.com/plugin/lwc");
             }
         }
         if (Bukkit.getPluginManager().getPlugin("Towny") != null) {


### PR DESCRIPTION
This change prevents the error thrown while attempting to register a listener for an event not present in modern Paper builds. In addition, it adds a warning that users should change their LWC version to one that's more correct for their system.