### PR TITLE
Improve performance of protection checks under Paper

### DIFF
--- a/src/main/java/com/griefcraft/bukkit/EntityBlock.java
+++ b/src/main/java/com/griefcraft/bukkit/EntityBlock.java
@@ -307,7 +307,7 @@ public class EntityBlock implements Block {
 
     @Override
     public @NotNull BlockState getState(boolean b) {
-        return null;
+        return new EntityBlockState(this);
     }
 
     @Override

--- a/src/main/java/com/griefcraft/bukkit/HopperMinecartBlock.java
+++ b/src/main/java/com/griefcraft/bukkit/HopperMinecartBlock.java
@@ -15,6 +15,10 @@ public class HopperMinecartBlock extends EntityBlock {
         return (BlockState) this.minecart.getInventory().getHolder();
     }
 
+    public BlockState getState(boolean useSnapshot) {
+        return (BlockState) this.minecart.getInventory().getHolder(useSnapshot);
+    }
+
     public HopperMinecart getMinecart() {
         return this.minecart;
     }

--- a/src/main/java/com/griefcraft/bukkit/StoreageMinecartBlock.java
+++ b/src/main/java/com/griefcraft/bukkit/StoreageMinecartBlock.java
@@ -15,6 +15,10 @@ public class StoreageMinecartBlock extends EntityBlock {
         return (BlockState) this.minecart.getInventory().getHolder();
     }
 
+    public BlockState getState(boolean useSnapshot) {
+        return (BlockState) this.minecart.getInventory().getHolder(useSnapshot);
+    }
+
     public StorageMinecart getMinecart() {
         return this.minecart;
     }

--- a/src/main/java/com/griefcraft/io/RestorableBlock.java
+++ b/src/main/java/com/griefcraft/io/RestorableBlock.java
@@ -101,12 +101,12 @@ public class RestorableBlock implements Restorable {
                 block.setType(blockCache.getBlockType(id));
 
                 if (items.size() > 0) {
-                    if (!(block.getState() instanceof InventoryHolder)) {
+                    if (!(block.getState(false) instanceof InventoryHolder)) {
                         lwc.log(String.format("The block at [%d, %d, %d] has backed up items but no longer supports them. Why? %s", x, y, z, block.toString()));
                     }
 
                     // Get the block's inventory
-                    Inventory inventory = ((InventoryHolder) block.getState()).getInventory();
+                    Inventory inventory = ((InventoryHolder) block.getState(false)).getInventory();
 
                     // Set all of the items to it
                     for (Map.Entry<Integer, ItemStack> entry : items.entrySet()) {
@@ -144,7 +144,7 @@ public class RestorableBlock implements Restorable {
         rblock.y = block.getY();
         rblock.z = block.getZ();
 
-        BlockState state = block.getState();
+        BlockState state = block.getState(false);
 
         // Does it have an inventory? ^^
         if (state instanceof InventoryHolder) {

--- a/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
@@ -280,7 +280,7 @@ public class LWCBlockListener implements Listener {
                 protection.radiusRemoveCache();
 
                 if (protection.getProtectionFinder() != null) {
-                    protection.getProtectionFinder().removeBlock(block.getState());
+                    protection.getProtectionFinder().removeBlock(block.getState(false));
                 }
 
                 lwc.getProtectionCache().addProtection(protection);
@@ -429,7 +429,7 @@ public class LWCBlockListener implements Listener {
             }
 
             // also check if the hopper is pointing into a protection
-            Hopper hopperData = (Hopper) block.getState().getBlockData();
+            Hopper hopperData = (Hopper) block.getState(false).getBlockData();
             Block target = block.getRelative(hopperData.getFacing());
             if (shouldBlockHopperPlacement(player, target)) {
                 event.setCancelled(true);
@@ -439,7 +439,7 @@ public class LWCBlockListener implements Listener {
     }
 
     private boolean shouldBlockHopperPlacement(Player player, Block block) {
-        if (block.getState() instanceof InventoryHolder) { // only care if block has an inventory
+        if (block.getState(false) instanceof InventoryHolder) { // only care if block has an inventory
             LWC lwc = plugin.getLWC();
             Protection protection = lwc.findProtection(block);
             if (protection != null) { // found protection
@@ -528,7 +528,7 @@ public class LWCBlockListener implements Listener {
         }
 
         // If it's a chest, make sure they aren't placing it beside an already registered chest
-        BlockState blockState = block.getState();
+        BlockState blockState = block.getState(false);
         Chest chestData = null;
         try {
             chestData = (Chest) blockState.getBlockData();

--- a/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -321,7 +321,7 @@ public class LWCPlayerListener implements Listener {
 
     @EventHandler
     public void storageMinecraftInventoryOpen(InventoryOpenEvent event) {
-        InventoryHolder holder = event.getInventory().getHolder();
+        InventoryHolder holder = event.getInventory().getHolder(false);
         Player player = (Player) event.getPlayer();
         if ((!(holder instanceof StorageMinecart)) && (!(holder instanceof HopperMinecart))) {
             return;
@@ -452,7 +452,7 @@ public class LWCPlayerListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onMoveItem(InventoryMoveItemEvent event) {
         if (plugin.getLWC().useAlternativeHopperProtection()
-                && !(event.getSource().getHolder() instanceof HopperMinecart || event.getDestination().getHolder() instanceof HopperMinecart)) {
+                && !(event.getSource().getHolder(false) instanceof HopperMinecart || event.getDestination().getHolder(false) instanceof HopperMinecart)) {
             return;
         }
 
@@ -489,8 +489,8 @@ public class LWCPlayerListener implements Listener {
         InventoryHolder initiatorHolder;
 
         try {
-            holder = inventory.getHolder();
-            initiatorHolder = initiator.getHolder();
+            holder = inventory.getHolder(false);
+            initiatorHolder = initiator.getHolder(false);
         } catch (AbstractMethodError e) {
             return false;
         }
@@ -592,7 +592,7 @@ public class LWCPlayerListener implements Listener {
             return;
         }
 
-        BlockState state = block.getState();
+        BlockState state = block.getState(false);
         // Prevent players with lwc.deny from interacting with blocks that have an inventory
         if (state instanceof InventoryHolder && lwc.isProtectable(block)) {
             if (!lwc.hasPermission(player, "lwc.protect") && lwc.hasPermission(player, "lwc.deny")
@@ -611,8 +611,8 @@ public class LWCPlayerListener implements Listener {
             Protection protection = lwc.findProtection(block.getLocation());
             boolean canAccess = lwc.canAccessProtection(player, protection);
 
-            if (canAccess && CHISELED_BOOKSHELF != null && CHISELED_BOOKSHELF.equals(block.getType()) && block.getState() instanceof ChiseledBookshelf && block.getBlockData() instanceof org.bukkit.block.data.type.ChiseledBookshelf) {
-                final ChiseledBookshelf chiseledBookshelf = (ChiseledBookshelf) block.getState();
+            if (canAccess && CHISELED_BOOKSHELF != null && CHISELED_BOOKSHELF.equals(block.getType()) && block.getState(false) instanceof ChiseledBookshelf && block.getBlockData() instanceof org.bukkit.block.data.type.ChiseledBookshelf) {
+                final ChiseledBookshelf chiseledBookshelf = (ChiseledBookshelf) block.getState(false);
                 final org.bukkit.block.data.type.ChiseledBookshelf chiseledBookshelfBlockData = (org.bukkit.block.data.type.ChiseledBookshelf) block.getBlockData();
                 if (chiseledBookshelfBlockData.getFacing() == event.getBlockFace()) {
                     final Vector clickedPosition = event.getClickedPosition();
@@ -778,7 +778,7 @@ public class LWCPlayerListener implements Listener {
         InventoryHolder holder = null;
 
         try {
-            holder = event.getInventory().getHolder();
+            holder = event.getInventory().getHolder(false);
         } catch (AbstractMethodError e) {
             e.printStackTrace();
             return;
@@ -949,7 +949,7 @@ public class LWCPlayerListener implements Listener {
         InventoryHolder holder = null;
 
         try {
-            holder = event.getInventory().getHolder();
+            holder = event.getInventory().getHolder(false);
         } catch (AbstractMethodError e) {
             e.printStackTrace();
             return;

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -311,7 +311,7 @@ public class LWC {
                     "findAdjacentDoubleChest() cannot be called on a: " + block.getType());
         }
 
-        BlockState baseBlockState = block.getState();
+        BlockState baseBlockState = block.getState(false);
         Chest baseBlockData = null;
         try {
             baseBlockData = (Chest) baseBlockState.getBlockData();
@@ -452,9 +452,8 @@ public class LWC {
     public Map<Integer, ItemStack> depositItems(Block block, ItemStack itemStack) {
         BlockState blockState;
 
-        if ((blockState = block.getState()) != null && (blockState instanceof InventoryHolder)) {
+        if (block.getState(false) instanceof InventoryHolder holder) {
             Block doubleChestBlock = null;
-            InventoryHolder holder = (InventoryHolder) blockState;
 
             if (DoubleChestMatcher.PROTECTABLES_CHESTS.contains(block.getType())) {
                 doubleChestBlock = findAdjacentDoubleChest(block);
@@ -489,7 +488,7 @@ public class LWC {
 
                 // is it a double chest ?????
                 if (doubleChestBlock != null) {
-                    InventoryHolder holder2 = (InventoryHolder) doubleChestBlock.getState();
+                    InventoryHolder holder2 = (InventoryHolder) doubleChestBlock.getState(false);
                     remaining = holder2.getInventory().addItem(remainingItemStack);
                 }
 
@@ -1273,11 +1272,10 @@ public class LWC {
             return;
         }
 
-        if (!(block.getState() instanceof InventoryHolder)) {
+        if (!(block.getState(false) instanceof InventoryHolder holder)) {
             return;
         }
 
-        InventoryHolder holder = (InventoryHolder) block.getState();
         holder.getInventory().clear();
     }
 
@@ -1318,7 +1316,7 @@ public class LWC {
      * @return
      */
     public Protection findProtection(Block block) {
-        return findProtection(block.getState());
+        return findProtection(block.getState(false));
     }
 
     public Protection findProtection(BlockState block) {
@@ -1861,11 +1859,10 @@ public class LWC {
 
         try {
             for (Block block : blocks) {
-                if (!(block.getState() instanceof InventoryHolder)) {
+                if (!(block.getState(false) instanceof InventoryHolder holder)) {
                     continue;
                 }
 
-                InventoryHolder holder = (InventoryHolder) block.getState();
                 Inventory inventory = holder.getInventory();
 
                 // Add all the items from this inventory

--- a/src/main/java/com/griefcraft/modules/admin/AdminView.java
+++ b/src/main/java/com/griefcraft/modules/admin/AdminView.java
@@ -80,12 +80,12 @@ public class AdminView extends JavaModule {
 
         Block block = world.getBlockAt(protection.getX(), protection.getY(), protection.getZ());
 
-        if (!(block.getState() instanceof InventoryHolder)) {
+        if (!(block.getState(false) instanceof InventoryHolder holder)) {
             lwc.sendLocale(sender, "protection.admin.view.noinventory");
             return;
         }
 
-        player.openInventory(((InventoryHolder) block.getState()).getInventory());
+        player.openInventory(holder.getInventory());
 
         lwc.sendLocale(sender, "protection.admin.view.viewing", "id", protectionId);
     }

--- a/src/main/java/com/griefcraft/modules/economy/EconomyModule.java
+++ b/src/main/java/com/griefcraft/modules/economy/EconomyModule.java
@@ -86,7 +86,7 @@ public class EconomyModule extends JavaModule {
             return;
 
         // is it actually a container? :p
-        if (!(protection.getBlock().getState() instanceof InventoryHolder))
+        if (!(protection.getBlock().getState(false) instanceof InventoryHolder))
             return;
 
         // Are they right clicking the chest (aka open) ?

--- a/src/main/java/com/griefcraft/modules/flag/MagnetModule.java
+++ b/src/main/java/com/griefcraft/modules/flag/MagnetModule.java
@@ -160,7 +160,7 @@ public class MagnetModule extends JavaModule {
                                     continue;
 
                                 // we only want inventory blocks
-                                if (!(protection.getBlock().getState() instanceof InventoryHolder)) {
+                                if (!(protection.getBlock().getState(false) instanceof InventoryHolder)) {
                                     continue;
                                 }
 

--- a/src/main/java/com/griefcraft/util/matchers/WallMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/WallMatcher.java
@@ -128,7 +128,7 @@ public class WallMatcher implements ProtectionFinder.Matcher {
         // Blocks such as wall signs or banners
         if ((PROTECTABLES_WALL.contains(block.getType()) || PROTECTABLES_LEVERS_ET_AL.contains(block.getType()))
                 && blockData instanceof Directional) {
-            if (((Directional) block.getState().getBlockData()).getFacing() == matchingFace) {
+            if (((Directional) block.getState(false).getBlockData()).getFacing() == matchingFace) {
                 return block;
             }
         }


### PR DESCRIPTION
Improve performance of protection checks under Paper by not creating a snapshot for each block.

Previously this could cause lag spikes if something (like hoppers or other plugins which move items) would check lots of blocks for protections at the same time. I tried to check the logic which uses those objects/methods whether they actually would require a snapshot and I couldn't find any.